### PR TITLE
chore: Node.jsを24系に更新

### DIFF
--- a/.github/workflows/build-commands.yml
+++ b/.github/workflows/build-commands.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '24'
         cache: 'npm'
         
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '24'
         cache: 'npm'
 
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build-only
 
 # Production stage
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",


### PR DESCRIPTION
## Summary
- Node.jsの実行環境を24系に統一
- Dockerfile（builder/production両方）を `node:22-alpine` → `node:24-alpine`
- GitHub Actions（`deploy.yml` / `build-commands.yml`）の `node-version` を `'18'` → `'24'`
- `package.json` に `engines.node: ">=24"` を追加

## 背景
- 既存環境の Node.js バージョンが Dockerfile（22）と CI（18）で乖離していたため、最新 LTS の v24 に統一
- ローカル開発環境（v24.12.0）と揃え、`@types/node@^24` に対応

## Test plan
- [ ] `npm run check`（型チェック + リント）がローカルで成功
- [ ] `npm test`（vitest）がローカルで成功
- [ ] `docker build -t discord-bot:test .` が成功
- [ ] `Build Commands` ワークフローを `workflow_dispatch` で動作確認
- [ ] mainマージ後、`Deploy to GCE` ワークフローでデプロイ成功 / ヘルスチェック通過