### PR TITLE
feat: 繰り返しタスクの完了時可変消費モードと在庫一括更新の改善

### DIFF
--- a/src/buttons/InventoryUpdateButtonHandler.ts
+++ b/src/buttons/InventoryUpdateButtonHandler.ts
@@ -76,7 +76,7 @@ export class InventoryUpdateButtonHandler extends BaseButtonHandler {
       .setCustomId('items')
       .setLabel('在庫一覧（名前,在庫数,カテゴリ）を編集')
       .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
+      .setRequired(false)
       .setMaxLength(4000)
       .setPlaceholder('例: 洗剤,3,日用品\n米,10,食品')
       .setValue(csvText);

--- a/src/buttons/InventoryUpdateButtonHandler.ts
+++ b/src/buttons/InventoryUpdateButtonHandler.ts
@@ -69,7 +69,7 @@ export class InventoryUpdateButtonHandler extends BaseButtonHandler {
 
   private buildModal(csvText: string): ModalBuilder {
     const modal = new ModalBuilder()
-      .setCustomId('inventory_update_modal')
+      .setCustomId(`inventory_update_modal:${Date.now()}`)
       .setTitle('在庫を更新');
 
     const itemsInput = new TextInputBuilder()

--- a/src/buttons/RemindTaskCompleteButtonHandler.ts
+++ b/src/buttons/RemindTaskCompleteButtonHandler.ts
@@ -210,7 +210,7 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
 
     const prefill = await this.buildVariableConsumptionPrefill(linkedInventoryChannelId, task);
     const modal = new ModalBuilder()
-      .setCustomId(`remind-task-complete-modal:${messageId}`)
+      .setCustomId(`remind-task-complete-modal:${messageId}:${Date.now()}`)
       .setTitle('完了時の消費数入力');
 
     const inventoryInput = new TextInputBuilder()
@@ -231,15 +231,19 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
   }
 
   private async buildVariableConsumptionPrefill(linkedInventoryChannelId: string, task: RemindTask): Promise<string> {
-    const lines = await Promise.all(task.inventoryItems.map(async (item) => {
+    const inventoryRepository = this.inventoryRepository ?? new InventoryRepository();
+    const inventoryItems = await inventoryRepository.fetchAll(linkedInventoryChannelId);
+    const inventoryItemsById = new Map(inventoryItems.map(inventoryItem => [inventoryItem.id, inventoryItem]));
+
+    const lines = task.inventoryItems.map((item) => {
       if (!isNewInventoryItem(item)) {
         return this.formatInventoryPrefillLine(item.name, item.consume);
       }
 
-      const inventoryItem = await this.inventoryService?.getById(linkedInventoryChannelId, item.inventoryId);
+      const inventoryItem = inventoryItemsById.get(item.inventoryId);
       const name = inventoryItem?.name ?? `[不明な在庫:${item.inventoryId.slice(0, 8)}]`;
       return this.formatInventoryPrefillLine(name, item.consume);
-    }));
+    });
     return lines.join('\n');
   }
 
@@ -320,6 +324,9 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
     }
     if (result.kind === 'migration_required') {
       return '在庫移行が必要です。先に在庫移行を実行してください。';
+    }
+    if (result.kind === 'error') {
+      return `在庫の更新に失敗しました: ${result.message}`;
     }
 
     const shortageNotice = formatInventoryShortageNotice(result.items as never);

--- a/src/buttons/RemindTaskCompleteButtonHandler.ts
+++ b/src/buttons/RemindTaskCompleteButtonHandler.ts
@@ -1,5 +1,7 @@
+import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from 'discord.js';
 import { Logger } from '../utils/logger';
 import type { InventoryItem } from '../models/InventoryItem';
+import { isNewInventoryItem, type RemindTask } from '../models/RemindTask';
 import { BaseButtonHandler, ButtonHandlerContext } from '../base/BaseButtonHandler';
 import { OperationInfo, OperationResult } from '../models/types/OperationLog';
 import { OperationLogService } from '../services/OperationLogService';
@@ -41,7 +43,7 @@ interface RefreshServicePort {
 export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
   private repository: RemindTaskRepository;
   private messageManager: RemindMessageManager;
-  private inventoryService?: Pick<InventoryService, 'consumeForTask'>;
+  private inventoryService?: Pick<InventoryService, 'consumeForTask' | 'getById'>;
   private inventoryRepository?: InventoryRepositoryPort;
   private inventoryMessageManager?: InventoryMessageManagerPort;
   private refreshService?: RefreshServicePort;
@@ -52,7 +54,7 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
     metadataManager?: MetadataProvider,
     repository?: RemindTaskRepository,
     messageManager?: RemindMessageManager,
-    inventoryService?: Pick<InventoryService, 'consumeForTask'>,
+    inventoryService?: Pick<InventoryService, 'consumeForTask' | 'getById'>,
     inventoryRepository?: InventoryRepositoryPort,
     inventoryMessageManager?: InventoryMessageManagerPort,
     refreshService?: RefreshServicePort
@@ -80,14 +82,15 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
 
   protected async executeAction(context: ButtonHandlerContext): Promise<OperationResult> {
     const interaction = context.interaction;
-
-    if (!interaction.deferred && !interaction.replied) {
-      await interaction.deferReply({ flags: ['Ephemeral'] as const });
-    }
+    let hasDeferredReply = Boolean(interaction.deferred);
 
     const replyError = async (message: string): Promise<OperationResult> => {
       try {
-        await interaction.editReply({ content: message });
+        if (hasDeferredReply || interaction.deferred || interaction.replied) {
+          await interaction.editReply({ content: message });
+        } else {
+          await interaction.reply({ content: message, flags: ['Ephemeral'] as const });
+        }
       } catch {
         // ignore reply failures
       }
@@ -104,6 +107,15 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
       const task = await this.repository.findTaskByMessageId(channelId, messageId);
       if (!task) {
         return await replyError('タスクが見つかりません');
+      }
+
+      if (this.hasVariableInventoryItem(task) && this.metadataManager && this.inventoryService?.getById) {
+        return await this.showVariableConsumptionModal(interaction, channelId, messageId, task);
+      }
+
+      if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply({ flags: ['Ephemeral'] as const });
+        hasDeferredReply = true;
       }
 
       let consumedInventory = task.inventoryItems;
@@ -175,6 +187,67 @@ export class RemindTaskCompleteButtonHandler extends BaseButtonHandler {
     } catch {
       return await replyError('処理中にエラーが発生しました');
     }
+  }
+
+  private hasVariableInventoryItem(task: RemindTask): boolean {
+    return task.inventoryItems.some(item => isNewInventoryItem(item) && item.consume === 0);
+  }
+
+  private async showVariableConsumptionModal(
+    interaction: ButtonHandlerContext['interaction'],
+    channelId: string,
+    messageId: string,
+    task: RemindTask
+  ): Promise<OperationResult> {
+    const metadataResult = await this.metadataManager?.getChannelMetadata(channelId);
+    const linkedInventoryChannelId = (metadataResult?.metadata as { linkedInventoryChannelId?: string } | undefined)
+      ?.linkedInventoryChannelId;
+    if (!linkedInventoryChannelId) {
+      const message = '在庫チャンネルが連携されていません';
+      await interaction.reply({ content: message, flags: ['Ephemeral'] as const });
+      return { success: false, message };
+    }
+
+    const prefill = await this.buildVariableConsumptionPrefill(linkedInventoryChannelId, task);
+    const modal = new ModalBuilder()
+      .setCustomId(`remind-task-complete-modal:${messageId}`)
+      .setTitle('完了時の消費数入力');
+
+    const inventoryInput = new TextInputBuilder()
+      .setCustomId('inventory-items')
+      .setLabel('消費数(名前,数 の形式 / 空欄でスキップor固定値)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false)
+      .setPlaceholder('例: 洗剤,2.5')
+      .setMaxLength(1000)
+      .setValue(prefill);
+
+    modal.addComponents(
+      new ActionRowBuilder<TextInputBuilder>().addComponents(inventoryInput)
+    );
+
+    await interaction.showModal(modal);
+    return { success: true };
+  }
+
+  private async buildVariableConsumptionPrefill(linkedInventoryChannelId: string, task: RemindTask): Promise<string> {
+    const lines = await Promise.all(task.inventoryItems.map(async (item) => {
+      if (!isNewInventoryItem(item)) {
+        return this.formatInventoryPrefillLine(item.name, item.consume);
+      }
+
+      const inventoryItem = await this.inventoryService?.getById(linkedInventoryChannelId, item.inventoryId);
+      const name = inventoryItem?.name ?? `[不明な在庫:${item.inventoryId.slice(0, 8)}]`;
+      return this.formatInventoryPrefillLine(name, item.consume);
+    }));
+    return lines.join('\n');
+  }
+
+  private formatInventoryPrefillLine(name: string, consume: number): string {
+    if (consume > 0) {
+      return `${name},${consume}`;
+    }
+    return `${name},`;
   }
 
   private async notifyInventory(channelId: string, message: string, client: ButtonHandlerContext['interaction']['client']): Promise<void> {

--- a/src/commands/UpdateInventoryCommand.ts
+++ b/src/commands/UpdateInventoryCommand.ts
@@ -52,7 +52,7 @@ export class UpdateInventoryCommand extends BaseCommand {
       .setCustomId('items')
       .setLabel('在庫一覧（名前,在庫数,カテゴリ）を編集')
       .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
+      .setRequired(false)
       .setMaxLength(4000)
       .setPlaceholder('例: 洗剤,3,日用品\n米,10,食品')
       .setValue(formatInventoryCsvText(items));

--- a/src/modals/InventoryUpdateModalHandler.ts
+++ b/src/modals/InventoryUpdateModalHandler.ts
@@ -4,16 +4,18 @@ import { BaseModalHandler, ModalHandlerContext } from '../base/BaseModalHandler'
 import type { InventoryItem } from '../models/InventoryItem';
 import type { OperationInfo, OperationResult } from '../models/types/OperationLog';
 import { InventoryMessageManager } from '../services/InventoryMessageManager';
+import { InventoryMetadataManager } from '../services/InventoryMetadataManager';
 import { InventoryRepository } from '../services/InventoryRepository';
-import { InventoryService } from '../services/InventoryService';
+import { InventoryService, type ReferencedTask } from '../services/InventoryService';
 import { RemindTaskRefreshService, type RefreshOptions } from '../services/RemindTaskRefreshService';
-import { parseInventoryCsvText } from '../utils/InventoryParser';
+import { orderInventoryItemsForCsv, parseInventoryCsvText } from '../utils/InventoryParser';
 import { Logger } from '../utils/logger';
 
 interface InventoryServicePort {
   create(channelId: string, item: InventoryItem): Promise<{ success: boolean; message?: string }>;
   update(channelId: string, item: InventoryItem): Promise<{ success: boolean; message?: string }>;
   delete(channelId: string, id: string): Promise<void>;
+  findReferencingTasks(channelId: string, id: string): Promise<ReferencedTask[]>;
 }
 
 interface InventoryRepositoryPort {
@@ -83,13 +85,36 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
     }
 
     const currentItems = await this.repository.fetchAll(channelId);
+    const defaultCategory = await this.resolveDefaultCategory(channelId);
+    const orderedCurrent = orderInventoryItemsForCsv(currentItems, defaultCategory);
     const currentByName = new Map(currentItems.map(item => [item.name, item]));
     const editedByName = new Map(editedItems.map(item => [item.name, item]));
     const deleteErrors: string[] = [];
 
+    const renames: Array<{ currentItem: InventoryItem; edited: typeof editedItems[number] }> = [];
+    const renamedIds = new Set<string>();
+    const renamedEditedNames = new Set<string>();
+    const pairLimit = Math.min(orderedCurrent.length, editedItems.length);
+    for (let i = 0; i < pairLimit; i++) {
+      const current = orderedCurrent[i];
+      const edited = editedItems[i];
+      if (editedByName.has(current.name) || currentByName.has(edited.name)) {
+        continue;
+      }
+      const references = await this.inventoryService.findReferencingTasks(channelId, current.id);
+      if (references.length === 0) {
+        continue;
+      }
+      renames.push({ currentItem: current, edited });
+      renamedIds.add(current.id);
+      renamedEditedNames.add(edited.name);
+    }
+
     for (const editedItem of editedItems) {
-      const currentItem = currentByName.get(editedItem.name);
-      if (currentItem) {
+      if (currentByName.has(editedItem.name)) {
+        continue;
+      }
+      if (renamedEditedNames.has(editedItem.name)) {
         continue;
       }
 
@@ -127,8 +152,24 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
       }
     }
 
+    for (const { currentItem, edited } of renames) {
+      const updateResult = await this.inventoryService.update(channelId, {
+        id: currentItem.id,
+        name: edited.name,
+        stock: edited.stock,
+        category: edited.category ?? ''
+      });
+
+      if (!updateResult.success) {
+        return { success: false, message: updateResult.message || `${edited.name}の更新に失敗しました` };
+      }
+    }
+
     for (const currentItem of currentItems) {
       if (editedByName.has(currentItem.name)) {
+        continue;
+      }
+      if (renamedIds.has(currentItem.id)) {
         continue;
       }
 
@@ -179,5 +220,21 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
 
   protected getSuccessMessage(): string {
     return '✅ 在庫アイテムを更新しました。';
+  }
+
+  private async resolveDefaultCategory(channelId: string): Promise<string | undefined> {
+    try {
+      const metadata = await InventoryMetadataManager.getInstance().getChannelMetadata(channelId);
+      const raw = metadata?.defaultCategory;
+      if (raw && raw.trim() !== '') {
+        return raw;
+      }
+    } catch (error) {
+      this.logger.warn('Failed to resolve default category for inventory update', {
+        channelId,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+    return undefined;
   }
 }

--- a/src/modals/InventoryUpdateModalHandler.ts
+++ b/src/modals/InventoryUpdateModalHandler.ts
@@ -61,7 +61,8 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
   }
 
   public shouldHandle(context: ModalHandlerContext): boolean {
-    return context.interaction.customId === InventoryUpdateModalHandler.customId;
+    return context.interaction.customId === InventoryUpdateModalHandler.customId
+      || context.interaction.customId.startsWith(`${InventoryUpdateModalHandler.customId}:`);
   }
 
   protected async executeAction(context: ModalHandlerContext): Promise<OperationResult> {

--- a/src/modals/InventoryUpdateModalHandler.ts
+++ b/src/modals/InventoryUpdateModalHandler.ts
@@ -181,13 +181,6 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
       }
     }
 
-    if (deleteErrors.length > 0) {
-      return {
-        success: false,
-        message: `削除できない在庫アイテムがあります。\n${deleteErrors.join('\n')}`
-      };
-    }
-
     const items = await this.repository.fetchAll(channelId);
     const messageResult = await this.messageManager.createOrUpdateMessage(
       channelId,
@@ -206,6 +199,13 @@ export class InventoryUpdateModalHandler extends BaseModalHandler {
         channelId,
         error: error instanceof Error ? error.message : 'Unknown error'
       });
+    }
+
+    if (deleteErrors.length > 0) {
+      return {
+        success: false,
+        message: `削除できない在庫アイテムがあります。\n${deleteErrors.join('\n')}`
+      };
     }
 
     return { success: true };

--- a/src/modals/RemindTaskCompleteModalHandler.ts
+++ b/src/modals/RemindTaskCompleteModalHandler.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../utils/logger';
 import type { InventoryItem } from '../models/InventoryItem';
+import { isNewInventoryItem, type NewRemindInventoryItem } from '../models/RemindTask';
 import { BaseModalHandler, ModalHandlerContext } from '../base/BaseModalHandler';
 import { OperationInfo, OperationResult } from '../models/types/OperationLog';
 import { OperationLogService } from '../services/OperationLogService';
@@ -8,9 +9,8 @@ import { RemindTaskRepository } from '../services/RemindTaskRepository';
 import { RemindMessageManager } from '../services/RemindMessageManager';
 import { calculateNextDueAt } from '../utils/RemindSchedule';
 import {
-  consumeInventory,
   formatInventoryShortageNotice,
-  getInsufficientInventoryItems
+  parseCompletionInput
 } from '../utils/RemindInventory';
 import { InventoryService, type ConsumeForTaskResult } from '../services/InventoryService';
 import { InventoryRepository } from '../services/InventoryRepository';
@@ -41,7 +41,7 @@ interface RefreshServicePort {
 export class RemindTaskCompleteModalHandler extends BaseModalHandler {
   private repository: RemindTaskRepository;
   private messageManager: RemindMessageManager;
-  private inventoryService?: Pick<InventoryService, 'consumeForTask'>;
+  private inventoryService: Pick<InventoryService, 'consumeForTask' | 'getById'>;
   private inventoryRepository?: InventoryRepositoryPort;
   private inventoryMessageManager?: InventoryMessageManagerPort;
   private refreshService?: RefreshServicePort;
@@ -52,7 +52,7 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
     metadataManager?: MetadataProvider,
     repository?: RemindTaskRepository,
     messageManager?: RemindMessageManager,
-    inventoryService?: Pick<InventoryService, 'consumeForTask'>,
+    inventoryService?: Pick<InventoryService, 'consumeForTask' | 'getById'>,
     inventoryRepository?: InventoryRepositoryPort,
     inventoryMessageManager?: InventoryMessageManagerPort,
     refreshService?: RefreshServicePort
@@ -62,7 +62,7 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
     this.silentOnSuccess = true;
     this.repository = repository || new RemindTaskRepository();
     this.messageManager = messageManager || new RemindMessageManager();
-    this.inventoryService = inventoryService ?? (process.env.NODE_ENV === 'test' ? undefined : InventoryService.getInstance());
+    this.inventoryService = inventoryService ?? InventoryService.getInstance();
     this.inventoryRepository = inventoryRepository;
     this.inventoryMessageManager = inventoryMessageManager;
     this.refreshService = refreshService;
@@ -95,28 +95,60 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
       return { success: false, message: 'タスクが見つかりません' };
     }
 
-    let consumedInventory = task.inventoryItems;
-    let nextInsufficientItems = getInsufficientInventoryItems(consumedInventory);
-    if (this.inventoryService) {
-      const inventoryResult = await this.inventoryService.consumeForTask(channelId, task);
+    const metadataResult = await this.metadataManager?.getChannelMetadata(channelId);
+    const linkedInventoryChannelId = (metadataResult?.metadata as { linkedInventoryChannelId?: string } | undefined)
+      ?.linkedInventoryChannelId;
+    if (!linkedInventoryChannelId) {
+      return { success: false, message: '在庫チャンネルが連携されていません' };
+    }
+
+    let completionInput: Array<{ name: string; consume: number | null }>;
+    try {
+      completionInput = parseCompletionInput(
+        context.interaction.fields.getTextInputValue('inventory-items')
+      );
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : '完了入力の形式が不正です'
+      };
+    }
+
+    const inputMap = new Map<string, number | null>(
+      completionInput.map(item => [item.name, item.consume])
+    );
+    const tempInventoryItems: NewRemindInventoryItem[] = [];
+
+    for (const item of task.inventoryItems) {
+      if (!isNewInventoryItem(item)) {
+        continue;
+      }
+
+      const inventoryItem = await this.inventoryService.getById(linkedInventoryChannelId, item.inventoryId);
+      if (!inventoryItem) {
+        if (item.consume > 0) {
+          tempInventoryItems.push({ inventoryId: item.inventoryId, consume: item.consume });
+        }
+        continue;
+      }
+
+      const input = inputMap.get(inventoryItem.name);
+      const effectiveConsume = this.resolveEffectiveConsume(item.consume, input);
+      if (effectiveConsume > 0) {
+        tempInventoryItems.push({ inventoryId: item.inventoryId, consume: effectiveConsume });
+      }
+    }
+
+    let consumed = false;
+    let inventoryResult: ConsumeForTaskResult = { kind: 'success' };
+    if (tempInventoryItems.length > 0) {
+      const tempTask = { ...task, inventoryItems: tempInventoryItems };
+      inventoryResult = await this.inventoryService.consumeForTask(channelId, tempTask);
       const blockedResult = this.toBlockedResult(task.title, inventoryResult);
       if (blockedResult) {
         return blockedResult;
       }
-      await this.refreshInventoryMessage(inventoryResult, context.interaction.client, messageId);
-      nextInsufficientItems = [];
-    } else {
-      const insufficientItems = getInsufficientInventoryItems(task.inventoryItems);
-      if (insufficientItems.length > 0) {
-        const shortageNotice = formatInventoryShortageNotice(insufficientItems);
-        return {
-          success: false,
-          message: `${task.title}の完了に必要な在庫が不足しています。\n${shortageNotice}`
-        };
-      }
-
-      consumedInventory = consumeInventory(task.inventoryItems);
-      nextInsufficientItems = getInsufficientInventoryItems(consumedInventory);
+      consumed = true;
     }
 
     const now = new Date();
@@ -132,7 +164,7 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
 
     const updatedTask = {
       ...task,
-      inventoryItems: consumedInventory,
+      inventoryItems: task.inventoryItems,
       lastDoneAt: now,
       nextDueAt,
       lastRemindDueAt: null,
@@ -148,16 +180,18 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
 
     await this.messageManager.updateTaskMessage(channelId, messageId, updatedTask, context.interaction.client, now);
 
-    if (nextInsufficientItems.length > 0) {
-      const shortageNotice = formatInventoryShortageNotice(nextInsufficientItems);
-      await this.notifyInventory(
-        channelId,
-        `@everyone ${task.title}の次回分に必要な在庫が不足しています。\n${shortageNotice}`,
-        context.interaction.client
-      );
+    if (consumed) {
+      await this.refreshInventoryMessage(inventoryResult, context.interaction.client, messageId);
     }
 
     return { success: true };
+  }
+
+  private resolveEffectiveConsume(originalConsume: number, input: number | null | undefined): number {
+    if (originalConsume > 0) {
+      return input && input > 0 ? input : originalConsume;
+    }
+    return input && input > 0 ? input : 0;
   }
 
   private async notifyInventory(channelId: string, message: string, client: ModalHandlerContext['interaction']['client']): Promise<void> {

--- a/src/modals/RemindTaskCompleteModalHandler.ts
+++ b/src/modals/RemindTaskCompleteModalHandler.ts
@@ -41,7 +41,7 @@ interface RefreshServicePort {
 export class RemindTaskCompleteModalHandler extends BaseModalHandler {
   private repository: RemindTaskRepository;
   private messageManager: RemindMessageManager;
-  private inventoryService: Pick<InventoryService, 'consumeForTask' | 'getById'>;
+  private inventoryService: Pick<InventoryService, 'consumeForTask'>;
   private inventoryRepository?: InventoryRepositoryPort;
   private inventoryMessageManager?: InventoryMessageManagerPort;
   private refreshService?: RefreshServicePort;
@@ -52,7 +52,7 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
     metadataManager?: MetadataProvider,
     repository?: RemindTaskRepository,
     messageManager?: RemindMessageManager,
-    inventoryService?: Pick<InventoryService, 'consumeForTask' | 'getById'>,
+    inventoryService?: Pick<InventoryService, 'consumeForTask'>,
     inventoryRepository?: InventoryRepositoryPort,
     inventoryMessageManager?: InventoryMessageManagerPort,
     refreshService?: RefreshServicePort
@@ -118,13 +118,18 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
       completionInput.map(item => [item.name, item.consume])
     );
     const tempInventoryItems: NewRemindInventoryItem[] = [];
+    const inventoryRepository = this.inventoryRepository ?? new InventoryRepository();
+    const inventoryItems = await inventoryRepository.fetchAll(linkedInventoryChannelId);
+    const inventoryItemMap = new Map<string, InventoryItem>(
+      inventoryItems.map(item => [item.id, item])
+    );
 
     for (const item of task.inventoryItems) {
       if (!isNewInventoryItem(item)) {
         continue;
       }
 
-      const inventoryItem = await this.inventoryService.getById(linkedInventoryChannelId, item.inventoryId);
+      const inventoryItem = inventoryItemMap.get(item.inventoryId);
       if (!inventoryItem) {
         if (item.consume > 0) {
           tempInventoryItems.push({ inventoryId: item.inventoryId, consume: item.consume });
@@ -260,7 +265,7 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
 
   private parseMessageId(customId: string): string | null {
     const parts = customId.split(':');
-    return parts.length === 2 ? parts[1] : null;
+    return parts.length >= 2 && parts[1] ? parts[1] : null;
   }
 
   private toBlockedResult(title: string, result: ConsumeForTaskResult): OperationResult | null {
@@ -271,6 +276,12 @@ export class RemindTaskCompleteModalHandler extends BaseModalHandler {
       return {
         success: false,
         message: '在庫移行が必要です。先に在庫移行を実行してください。'
+      };
+    }
+    if (result.kind === 'error') {
+      return {
+        success: false,
+        message: `在庫の更新に失敗しました: ${result.message}`
       };
     }
 

--- a/src/modals/RemindTaskInventoryModalHandler.ts
+++ b/src/modals/RemindTaskInventoryModalHandler.ts
@@ -111,6 +111,7 @@ export class RemindTaskInventoryModalHandler extends BaseModalHandler {
           return { success: false, message: '在庫チャンネルが連携されていません' };
         }
         const parsedItems = parseInventoryInput(input);
+
         let stockUpdated = false;
         inventoryItems = [];
         for (const item of parsedItems) {
@@ -197,6 +198,6 @@ export class RemindTaskInventoryModalHandler extends BaseModalHandler {
 
   private parseMessageId(customId: string): string | null {
     const parts = customId.split(':');
-    return parts.length === 2 ? parts[1] : null;
+    return parts.length >= 2 && parts[1] ? parts[1] : null;
   }
 }

--- a/src/modals/RemindTaskUpdateModalHandler.ts
+++ b/src/modals/RemindTaskUpdateModalHandler.ts
@@ -109,6 +109,6 @@ export class RemindTaskUpdateModalHandler extends BaseModalHandler {
 
   private parseMessageId(customId: string): string | null {
     const parts = customId.split(':');
-    return parts.length === 2 ? parts[1] : null;
+    return parts.length >= 2 && parts[1] ? parts[1] : null;
   }
 }

--- a/src/modals/RemindTaskUpdateOverrideModalHandler.ts
+++ b/src/modals/RemindTaskUpdateOverrideModalHandler.ts
@@ -117,7 +117,7 @@ export class RemindTaskUpdateOverrideModalHandler extends BaseModalHandler {
 
   private parseMessageId(customId: string): string | null {
     const parts = customId.split(':');
-    return parts.length === 2 ? parts[1] : null;
+    return parts.length >= 2 && parts[1] ? parts[1] : null;
   }
 
   private parseOverrideDate(input: string, fallbackTimeOfDay: string, label: string): Date | undefined {

--- a/src/models/RemindTask.ts
+++ b/src/models/RemindTask.ts
@@ -114,7 +114,7 @@ export function validateRemindTask(task: RemindTask): void {
       if (!item.inventoryId || item.inventoryId.trim() === '') {
         throw new Error('inventory_itemsの在庫IDが無効です');
       }
-      if (!Number.isFinite(item.consume) || item.consume <= 0) {
+      if (!Number.isFinite(item.consume) || item.consume < 0) {
         throw new Error('inventory_itemsの消費数が無効です');
       }
       continue;

--- a/src/selectmenus/RemindTaskUpdateSelectMenuHandler.ts
+++ b/src/selectmenus/RemindTaskUpdateSelectMenuHandler.ts
@@ -99,7 +99,7 @@ export class RemindTaskUpdateSelectMenuHandler extends BaseSelectMenuHandler {
 
   private buildBasicModal(task: RemindTask, messageId: string): ModalBuilder {
     const modal = new ModalBuilder()
-      .setCustomId(`remind-task-update-modal:${messageId}`)
+      .setCustomId(`remind-task-update-modal:${messageId}:${Date.now()}`)
       .setTitle('リマインド更新');
 
     const titleInput = new TextInputBuilder()
@@ -155,7 +155,7 @@ export class RemindTaskUpdateSelectMenuHandler extends BaseSelectMenuHandler {
 
   private buildAdvancedModal(task: RemindTask, messageId: string): ModalBuilder {
     const modal = new ModalBuilder()
-      .setCustomId(`remind-task-update-override-modal:${messageId}`)
+      .setCustomId(`remind-task-update-override-modal:${messageId}:${Date.now()}`)
       .setTitle('詳細設定');
 
     const lastDoneValue = task.lastDoneAt ? this.formatTokyoDateTime(task.lastDoneAt) : '';
@@ -202,7 +202,7 @@ export class RemindTaskUpdateSelectMenuHandler extends BaseSelectMenuHandler {
 
   private async buildInventoryModal(channelId: string, task: RemindTask, messageId: string): Promise<ModalBuilder> {
     const modal = new ModalBuilder()
-      .setCustomId(`remind-task-inventory-modal:${messageId}`)
+      .setCustomId(`remind-task-inventory-modal:${messageId}:${Date.now()}`)
       .setTitle('在庫設定');
 
     const inventoryInput = new TextInputBuilder()

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -79,6 +79,10 @@ export class GoogleSheetsService {
   private readonly maxRetries = 3;
   private readonly retryDelay = 1000;
   private readonly logger = LoggerManager.getLogger('GoogleSheetsService');
+  private readonly sheetCache = new Map<string, { data: string[][]; expiresAt: number }>();
+  private readonly cacheTtlMs = 5000; // 5 秒
+  private readonly writeThroughTtlMs = 60000; // 60 秒
+  private readonly inFlightRequests = new Map<string, Promise<string[][]>>();
   
   // Atomic操作用のロックメカニズム
   private readonly operationLocks = new Map<string, Promise<void>>();
@@ -309,6 +313,7 @@ export class GoogleSheetsService {
         }
       });
 
+      this.invalidateSheetCache(sheetName);
       return { success: true, sheetId: sheet.properties.sheetId };
     } catch (error) {
       return { success: false, message: (error as Error).message };
@@ -331,7 +336,35 @@ export class GoogleSheetsService {
     });
   }
 
-  public async getSheetDataByName(sheetName: string): Promise<string[][]> {
+  public async getSheetDataByName(
+    sheetName: string,
+    options?: { skipCache?: boolean }
+  ): Promise<string[][]> {
+    if (options?.skipCache) {
+      return this.fetchSheetDataByName(sheetName, false);
+    }
+
+    const cached = this.sheetCache.get(sheetName);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+
+    const inFlightRequest = this.inFlightRequests.get(sheetName);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
+    const request = this.fetchSheetDataByName(sheetName, true);
+    this.inFlightRequests.set(sheetName, request);
+
+    try {
+      return await request;
+    } finally {
+      this.inFlightRequests.delete(sheetName);
+    }
+  }
+
+  private async fetchSheetDataByName(sheetName: string, shouldCache: boolean): Promise<string[][]> {
     return this.executeWithRetry(async () => {
       await this.getAuthClient();
 
@@ -341,13 +374,21 @@ export class GoogleSheetsService {
           range: `${sheetName}!A:Z`
         });
 
+        const data = response.data.values || [];
+        if (shouldCache) {
+          this.sheetCache.set(sheetName, {
+            data,
+            expiresAt: Date.now() + this.cacheTtlMs
+          });
+        }
+
         this.logger.info('Sheet data retrieved successfully', 
           ConsoleMigrationHelper.createMetadata('GoogleSheetsService', 'getSheetDataByName', {
             sheetName,
-            dataLength: response.data.values?.length || 0
+            dataLength: data.length
           }));
 
-        return response.data.values || [];
+        return data;
       } catch (error) {
         const gaxiosError = error as { code?: number; status?: number; message: string };
         this.logger.error('Failed to get sheet data', 
@@ -360,9 +401,17 @@ export class GoogleSheetsService {
 
         // シートが存在しない場合（400エラー + "Unable to parse range"）は空配列を返す
         if (gaxiosError.code === 400 && gaxiosError.message.includes('Unable to parse range')) {
+          const data: string[][] = [];
+          if (shouldCache) {
+            this.sheetCache.set(sheetName, {
+              data,
+              expiresAt: Date.now() + this.cacheTtlMs
+            });
+          }
+
           this.logger.info('Sheet does not exist, returning empty array', 
             ConsoleMigrationHelper.createMetadata('GoogleSheetsService', 'getSheetDataByName', { sheetName }));
-          return [];
+          return data;
         }
 
         throw error;
@@ -375,11 +424,7 @@ export class GoogleSheetsService {
       await this.getAuthClient();
       // sheetNameOrChannelIdが既にシート名（'metadata'等）の場合はそのまま使用、
       // channelIDらしき場合はgetSheetNameForChannelを呼ぶ
-      const sheetName = sheetNameOrChannelId.includes('!') 
-        ? sheetNameOrChannelId.split('!')[0]
-        : this.isKnownSheetName(sheetNameOrChannelId)
-          ? sheetNameOrChannelId
-          : this.getSheetNameForChannel(sheetNameOrChannelId);
+      const sheetName = this.resolveSheetName(sheetNameOrChannelId);
       
       await this.sheets.spreadsheets.values.append({
         spreadsheetId: this.config.spreadsheetId,
@@ -395,6 +440,7 @@ export class GoogleSheetsService {
         await this.applyHeaderFormatting(sheetNameOrChannelId, data[0].length);
       }
 
+      this.invalidateSheetCache(sheetName);
       return { success: true };
     } catch (error) {
       return { success: false, message: (error as Error).message };
@@ -409,13 +455,9 @@ export class GoogleSheetsService {
     data: (string | number)[][], 
     range?: string
   ): Promise<OperationResult> {
+    const sheetName = this.resolveSheetName(sheetNameOrChannelId);
     try {
       await this.getAuthClient();
-      const sheetName = sheetNameOrChannelId.includes('!') 
-        ? sheetNameOrChannelId.split('!')[0]
-        : this.isKnownSheetName(sheetNameOrChannelId)
-          ? sheetNameOrChannelId
-          : this.getSheetNameForChannel(sheetNameOrChannelId);
       
       // 範囲が指定されている場合はその範囲のみ更新
       if (range) {
@@ -428,6 +470,8 @@ export class GoogleSheetsService {
             values: data
           }
         });
+
+        this.invalidateSheetCache(sheetName);
       } else {
         // 範囲が指定されていない場合は従来通りシート全体を更新
         const updateRange = `${sheetName}!A:Z`;
@@ -447,10 +491,24 @@ export class GoogleSheetsService {
             values: data
           }
         });
+
+        this.sheetCache.set(sheetName, {
+          data: data.map((row) => row.map((cell) => String(cell))),
+          expiresAt: Date.now() + this.writeThroughTtlMs
+        });
       }
 
       return { success: true };
     } catch (error) {
+      this.logger.error('Sheet data update failed',
+        ConsoleMigrationHelper.createMetadata('GoogleSheetsService', 'updateSheetData', {
+          spreadsheetId: this.config.spreadsheetId,
+          sheetName,
+          range,
+          dataLength: data.length,
+          errorMessage: error instanceof Error ? error.message : 'Unknown error',
+          errorStack: error instanceof Error ? error.stack : undefined
+        }));
       return { success: false, message: (error as Error).message };
     }
   }
@@ -543,6 +601,7 @@ export class GoogleSheetsService {
         }
       });
 
+      this.invalidateSheetCache(sheetName);
       return true;
     } catch (error) {
       this.logger.error('Failed to rollback data for sheet', 
@@ -601,6 +660,7 @@ export class GoogleSheetsService {
         }
       });
 
+      this.invalidateSheetCache(sheetName);
       return { success: true };
     } catch (error) {
       return {
@@ -626,11 +686,7 @@ export class GoogleSheetsService {
 
     try {
       await this.getAuthClient();
-      const sheetName = sheetNameOrChannelId.includes('!') 
-        ? sheetNameOrChannelId.split('!')[0]
-        : this.isKnownSheetName(sheetNameOrChannelId)
-          ? sheetNameOrChannelId
-          : this.getSheetNameForChannel(sheetNameOrChannelId);
+      const sheetName = this.resolveSheetName(sheetNameOrChannelId);
 
       // ロックを取得してatomic操作を保証
       releaseLock = await this.acquireOperationLock(lockKey);
@@ -722,11 +778,7 @@ export class GoogleSheetsService {
       // ロールバックを試行
       if (operationStarted && backupData.length > 0) {
         try {
-          const sheetName = sheetNameOrChannelId.includes('!') 
-            ? sheetNameOrChannelId.split('!')[0]
-            : this.isKnownSheetName(sheetNameOrChannelId)
-              ? sheetNameOrChannelId
-              : this.getSheetNameForChannel(sheetNameOrChannelId);
+          const sheetName = this.resolveSheetName(sheetNameOrChannelId);
           
           const rollbackSuccess = await this.rollbackData(sheetName, backupData);
           if (rollbackSuccess) {
@@ -761,11 +813,7 @@ export class GoogleSheetsService {
       await this.getAuthClient();
       // sheetNameOrChannelIdが既にシート名（'metadata'等）の場合はそのまま使用、
       // channelIDらしき場合はgetSheetNameForChannelを呼ぶ
-      const sheetName = sheetNameOrChannelId.includes('!') 
-        ? sheetNameOrChannelId.split('!')[0]
-        : this.isKnownSheetName(sheetNameOrChannelId)
-          ? sheetNameOrChannelId
-          : this.getSheetNameForChannel(sheetNameOrChannelId);
+      const sheetName = this.resolveSheetName(sheetNameOrChannelId);
       
       // シート情報を取得してsheetIdを特定
       const spreadsheetResponse = await this.sheets.spreadsheets.get({
@@ -1011,6 +1059,18 @@ export class GoogleSheetsService {
     return /^\d{4}[/-]\d{1,2}[/-]\d{1,2}$/.test(str);
   }
 
+  private resolveSheetName(sheetNameOrChannelId: string): string {
+    return sheetNameOrChannelId.includes('!')
+      ? sheetNameOrChannelId.split('!')[0]
+      : this.isKnownSheetName(sheetNameOrChannelId)
+        ? sheetNameOrChannelId
+        : this.getSheetNameForChannel(sheetNameOrChannelId);
+  }
+
+  private invalidateSheetCache(sheetName: string): void {
+    this.sheetCache.delete(sheetName);
+  }
+
   private isKnownSheetName(sheetName: string): boolean {
     return (
       sheetName === 'metadata'
@@ -1203,6 +1263,7 @@ export class GoogleSheetsService {
         }
       });
       
+      this.invalidateSheetCache(sheetName);
       return { success: true };
     }
     
@@ -1260,6 +1321,7 @@ export class GoogleSheetsService {
       }
     });
     
+    this.invalidateSheetCache(sheetName);
     return { success: true };
   }
 

--- a/src/services/InventoryMetadataManager.ts
+++ b/src/services/InventoryMetadataManager.ts
@@ -94,7 +94,10 @@ export class InventoryMetadataManager {
       lastSyncTime?: Date;
     }
   ): Promise<OperationResult> {
-    const sheetData = await this.googleSheetsService.getSheetDataByName(this.METADATA_SHEET_NAME);
+    const sheetData = await this.googleSheetsService.getSheetDataByName(
+      this.METADATA_SHEET_NAME,
+      { skipCache: true }
+    );
     if (sheetData.length <= 1) {
       return { success: false, message: 'metadataが見つかりません' };
     }

--- a/src/services/InventoryMigrationService.ts
+++ b/src/services/InventoryMigrationService.ts
@@ -45,7 +45,7 @@ interface RemindMetadataReader {
 
 interface BackupSheetService {
   createSheetByName(sheetName: string): Promise<OperationResult>;
-  getSheetDataByName(sheetName: string): Promise<string[][]>;
+  getSheetDataByName(sheetName: string, options?: { skipCache?: boolean }): Promise<string[][]>;
   appendSheetData(sheetName: string, data: (string | number)[][]): Promise<OperationResult>;
 }
 

--- a/src/services/InventoryRepository.ts
+++ b/src/services/InventoryRepository.ts
@@ -1,6 +1,7 @@
 import { GoogleSheetsService, OperationResult } from './GoogleSheetsService';
 import type { InventoryItem } from '../models/InventoryItem';
 import { fromSheetRow, getInventorySheetHeaders, toSheetRow } from '../utils/InventorySheetMapper';
+import { LoggerManager } from '../utils/LoggerManager';
 
 interface InventoryWriteOptions {
   useLock?: boolean;
@@ -8,6 +9,7 @@ interface InventoryWriteOptions {
 
 export class InventoryRepository {
   private googleSheetsService: GoogleSheetsService;
+  private readonly logger = LoggerManager.getLogger('InventoryRepository');
 
   constructor() {
     this.googleSheetsService = GoogleSheetsService.getInstance();
@@ -55,16 +57,73 @@ export class InventoryRepository {
   ): Promise<OperationResult> {
     const operation = async (): Promise<OperationResult> => {
       const sheetName = this.getSheetNameForChannel(channelId);
-      const data = await this.googleSheetsService.getSheetDataByName(sheetName);
+      const data = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
       const headers = data[0] ?? getInventorySheetHeaders();
       const targetIndex = data.findIndex((row, index) => index > 0 && row[0] === item.id);
       if (targetIndex === -1) {
         return { success: false, message: 'Item not found' };
       }
 
-      const rows: (string | number)[][] = data.slice(1);
-      rows[targetIndex - 1] = toSheetRow(item);
+      const rows: string[][] = data.slice(1).map(row => row.map(cell => String(cell)));
+      rows[targetIndex - 1] = toSheetRow(item).map(value => String(value));
       return this.googleSheetsService.updateSheetData(sheetName, [headers, ...rows]);
+    };
+
+    if (options.useLock === false) {
+      return operation();
+    }
+
+    return this.googleSheetsService.runWithLock(this.getLockKeyForChannel(channelId), operation);
+  }
+
+  public async bulkUpdate(
+    channelId: string,
+    items: InventoryItem[],
+    options: InventoryWriteOptions = { useLock: true }
+  ): Promise<OperationResult> {
+    if (items.length === 0) {
+      this.logger.info('Inventory bulk update succeeded', {
+        component: 'InventoryRepository',
+        method: 'bulkUpdate',
+        channelId,
+        updatedRows: 0
+      });
+      return { success: true };
+    }
+
+    const operation = async (): Promise<OperationResult> => {
+      const sheetName = this.getSheetNameForChannel(channelId);
+      const data = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
+      const headers = data[0] ?? getInventorySheetHeaders();
+      const rows: string[][] = data.slice(1).map(row => row.map(cell => String(cell)));
+      const itemsById = new Map(items.map(item => [item.id, item]));
+      let updatedRows = 0;
+      const rewrittenRows = rows.map(row => {
+        const item = itemsById.get(row[0]);
+        if (item) {
+          updatedRows += 1;
+        }
+        return item ? toSheetRow(item).map(value => String(value)) : row;
+      });
+
+      const result = await this.googleSheetsService.updateSheetData(sheetName, [headers, ...rewrittenRows]);
+      if (result.success === false) {
+        this.logger.warn('Inventory bulk update failed', {
+          component: 'InventoryRepository',
+          method: 'bulkUpdate',
+          channelId,
+          itemCount: items.length,
+          message: result.message
+        });
+      } else {
+        this.logger.info('Inventory bulk update succeeded', {
+          component: 'InventoryRepository',
+          method: 'bulkUpdate',
+          channelId,
+          updatedRows
+        });
+      }
+      return result;
     };
 
     if (options.useLock === false) {
@@ -77,7 +136,7 @@ export class InventoryRepository {
   public async delete(channelId: string, id: string): Promise<OperationResult> {
     return this.googleSheetsService.runWithLock(this.getLockKeyForChannel(channelId), async () => {
       const sheetName = this.getSheetNameForChannel(channelId);
-      const data = await this.googleSheetsService.getSheetDataByName(sheetName);
+      const data = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
       const headers = data[0] ?? getInventorySheetHeaders();
       const rows = data.slice(1).filter(row => row[0] !== id);
       return this.googleSheetsService.updateSheetData(sheetName, [headers, ...rows]);

--- a/src/services/InventoryService.ts
+++ b/src/services/InventoryService.ts
@@ -29,7 +29,7 @@ export type ConsumeForTaskResult =
   | { kind: 'migration_required' }
   | { kind: 'error'; message: string };
 
-interface ReferencedTask {
+export interface ReferencedTask {
   channelId: string;
   title: string;
 }
@@ -121,6 +121,17 @@ export class InventoryService {
   }
 
   public async delete(channelId: string, id: string): Promise<void> {
+    const references = await this.findReferencingTasks(channelId, id);
+
+    if (references.length > 0) {
+      const referenceLines = references.map(reference => `- ${reference.channelId}: ${reference.title}`).join('\n');
+      throw new Error(`在庫アイテムを削除できません: 参照中のタスクがあります\n${referenceLines}`);
+    }
+
+    await this.inventoryRepository.delete(channelId, id);
+  }
+
+  public async findReferencingTasks(channelId: string, id: string): Promise<ReferencedTask[]> {
     const taskChannelIds = await this.remindMetadataManager.findChannelsLinkedToInventory(channelId);
     const references: ReferencedTask[] = [];
 
@@ -129,12 +140,7 @@ export class InventoryService {
       references.push(...this.findReferencedTasks(taskChannelId, tasks, id));
     }
 
-    if (references.length > 0) {
-      const referenceLines = references.map(reference => `- ${reference.channelId}: ${reference.title}`).join('\n');
-      throw new Error(`在庫アイテムを削除できません: 参照中のタスクがあります\n${referenceLines}`);
-    }
-
-    await this.inventoryRepository.delete(channelId, id);
+    return references;
   }
 
   public async consumeForTask(taskChannelId: string, task: RemindTask): Promise<ConsumeForTaskResult> {

--- a/src/services/InventoryService.ts
+++ b/src/services/InventoryService.ts
@@ -6,8 +6,12 @@ import { InventoryRepository } from './InventoryRepository';
 import { GoogleSheetsService, type OperationResult } from './GoogleSheetsService';
 import { RemindMetadataManager } from './RemindMetadataManager';
 import { RemindTaskRepository } from './RemindTaskRepository';
+import { LoggerManager } from '../utils/LoggerManager';
 
-type InventoryRepositoryPort = Pick<InventoryRepository, 'findByName' | 'findById' | 'append' | 'update' | 'delete'>;
+type InventoryRepositoryPort = Pick<
+  InventoryRepository,
+  'findByName' | 'findById' | 'append' | 'update' | 'bulkUpdate' | 'delete' | 'fetchAll'
+>;
 type RemindMetadataManagerPort = Pick<RemindMetadataManager, 'findChannelsLinkedToInventory' | 'getChannelMetadata'>;
 type RemindTaskRepositoryPort = Pick<RemindTaskRepository, 'fetchTasks'>;
 type GoogleSheetsServicePort = Pick<GoogleSheetsService, 'runWithLock'>;
@@ -22,7 +26,8 @@ export interface ShortageItem {
 export type ConsumeForTaskResult =
   | { kind: 'success'; linkedInventoryChannelId?: string }
   | { kind: 'shortage'; items: ShortageItem[] }
-  | { kind: 'migration_required' };
+  | { kind: 'migration_required' }
+  | { kind: 'error'; message: string };
 
 interface ReferencedTask {
   channelId: string;
@@ -31,6 +36,7 @@ interface ReferencedTask {
 
 export class InventoryService {
   private static instance: InventoryService | undefined;
+  private readonly logger = LoggerManager.getLogger('InventoryService');
 
   constructor(
     private readonly inventoryRepository: InventoryRepositoryPort,
@@ -168,11 +174,30 @@ export class InventoryService {
       return { kind: 'shortage', items: shortages };
     }
 
-    for (const stockedItem of stockedItems) {
-      await this.inventoryRepository.update(linkedInventoryChannelId, {
-        ...stockedItem.item,
-        stock: stockedItem.item.stock - stockedItem.request.consume
-      }, { useLock: false });
+    const updatedItems = stockedItems.map(stockedItem => ({
+      ...stockedItem.item,
+      stock: stockedItem.item.stock - stockedItem.request.consume
+    }));
+
+    const result = await this.inventoryRepository.bulkUpdate(linkedInventoryChannelId, updatedItems, { useLock: false });
+
+    if (result.success === false) {
+      const message = result.message ?? 'Unknown error';
+      this.logger.warn('Inventory consumption bulk update failed', {
+        component: 'InventoryService',
+        method: 'consumeInventoryItems',
+        linkedInventoryChannelId,
+        itemCount: updatedItems.length,
+        message
+      });
+      this.logger.error('Inventory consumption failed', {
+        component: 'InventoryService',
+        method: 'consumeInventoryItems',
+        linkedInventoryChannelId,
+        itemCount: updatedItems.length,
+        message
+      });
+      return { kind: 'error', message };
     }
 
     return { kind: 'success', linkedInventoryChannelId };
@@ -182,10 +207,12 @@ export class InventoryService {
     linkedInventoryChannelId: string,
     inventoryItems: NewRemindInventoryItem[]
   ): Promise<ShortageItem[]> {
+    const inventory = await this.inventoryRepository.fetchAll(linkedInventoryChannelId);
+    const inventoryById = new Map(inventory.map(item => [item.id, item]));
     const shortages: ShortageItem[] = [];
 
     for (const request of inventoryItems) {
-      const item = await this.inventoryRepository.findById(linkedInventoryChannelId, request.inventoryId);
+      const item = inventoryById.get(request.inventoryId);
       if (!item) {
         shortages.push({
           inventoryId: request.inventoryId,
@@ -216,11 +243,13 @@ export class InventoryService {
       stockedItems: Array<{ request: NewRemindInventoryItem; item: InventoryItem }>;
       shortages: ShortageItem[];
     }> {
+    const inventory = await this.inventoryRepository.fetchAll(linkedInventoryChannelId);
+    const inventoryById = new Map(inventory.map(item => [item.id, item]));
     const stockedItems: Array<{ request: NewRemindInventoryItem; item: InventoryItem }> = [];
     const shortages: ShortageItem[] = [];
 
     for (const request of inventoryItems) {
-      const item = await this.inventoryRepository.findById(linkedInventoryChannelId, request.inventoryId);
+      const item = inventoryById.get(request.inventoryId);
       if (!item) {
         shortages.push({
           inventoryId: request.inventoryId,

--- a/src/services/MetadataManager.ts
+++ b/src/services/MetadataManager.ts
@@ -90,7 +90,10 @@ export class MetadataManager {
     
     // APIからデータを取得してキャッシュを更新
     try {
-      this.cachedSheetData = await this.googleSheetsService.getSheetDataByName(this.METADATA_SHEET_NAME);
+      this.cachedSheetData = await this.googleSheetsService.getSheetDataByName(
+        this.METADATA_SHEET_NAME,
+        forceRefresh ? { skipCache: true } : undefined
+      );
       this.lastCacheTime = now;
       return this.cachedSheetData;
     } catch (error) {
@@ -378,7 +381,7 @@ export class MetadataManager {
       }
 
       // 既存データの検索と更新（キャッシュを使用）
-      const data = await this.getCachedSheetData();
+      const data = await this.getCachedSheetData(true);
       
       // 更新対象行を検索
       let targetRowIndex = -1;
@@ -518,7 +521,7 @@ export class MetadataManager {
       const updatedMetadata = updateSyncTime(metadata);
 
       // metadataシートから直接データを取得（キャッシュを使用、getChannelMetadataを使わない）
-      const data = await this.getCachedSheetData();
+      const data = await this.getCachedSheetData(true);
       
       // 更新対象行を検索
       let targetRowIndex = -1;

--- a/src/services/RemindMetadataManager.ts
+++ b/src/services/RemindMetadataManager.ts
@@ -112,7 +112,10 @@ export class RemindMetadataManager {
     channelId: string,
     updates: Partial<Omit<RemindChannelMetadata, 'channelId'>>
   ): Promise<RemindMetadataOperationResult> {
-    let sheetData = await this.googleSheetsService.getSheetDataByName(this.METADATA_SHEET_NAME);
+    let sheetData = await this.googleSheetsService.getSheetDataByName(
+      this.METADATA_SHEET_NAME,
+      { skipCache: true }
+    );
     if (sheetData.length <= 1) {
       return { success: false, message: 'metadataが見つかりません' };
     }

--- a/src/services/RemindSheetManager.ts
+++ b/src/services/RemindSheetManager.ts
@@ -41,7 +41,7 @@ export class RemindSheetManager {
 
   public async getOrCreateChannelSheet(channelId: string): Promise<RemindSheetResult> {
     const sheetName = this.getSheetNameForChannel(channelId);
-    const existingData = await this.googleSheetsService.getSheetDataByName(sheetName);
+    const existingData = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
 
     if (existingData.length > 0) {
       return { existed: true, data: existingData };

--- a/src/services/RemindTaskRepository.ts
+++ b/src/services/RemindTaskRepository.ts
@@ -36,7 +36,7 @@ export class RemindTaskRepository {
 
   public async updateTask(channelId: string, task: RemindTask): Promise<OperationResult> {
     const sheetName = this.getSheetNameForChannel(channelId);
-    const data = await this.googleSheetsService.getSheetDataByName(sheetName);
+    const data = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
     if (data.length === 0) {
       return { success: false, message: 'Sheet is empty' };
     }
@@ -79,7 +79,7 @@ export class RemindTaskRepository {
 
   public async deleteTask(channelId: string, taskId: string): Promise<OperationResult> {
     const sheetName = this.getSheetNameForChannel(channelId);
-    const data = await this.googleSheetsService.getSheetDataByName(sheetName);
+    const data = await this.googleSheetsService.getSheetDataByName(sheetName, { skipCache: true });
     if (data.length === 0) {
       return { success: false, message: 'Sheet is empty' };
     }

--- a/src/utils/InventoryParser.ts
+++ b/src/utils/InventoryParser.ts
@@ -53,22 +53,20 @@ export const parseInventoryCsvText = (text: string): InventoryCsvItem[] => {
   });
 };
 
-export const formatInventoryCsvText = (
-  items: Pick<InventoryItem, 'name' | 'stock' | 'category'>[],
+export const orderInventoryItemsForCsv = <T extends Pick<InventoryItem, 'name' | 'stock' | 'category'>>(
+  items: T[],
   defaultCategory?: string
-): string => {
-  const enriched = items.map(item => ({
-    ...item,
-    category: item.category && item.category.trim() !== '' ? item.category : (defaultCategory ?? '')
-  }));
-
-  const grouped = new Map<string, typeof enriched>();
-  for (const item of enriched) {
-    const cat = item.category || DEFAULT_CATEGORY;
-    if (!grouped.has(cat)) {
-      grouped.set(cat, []);
+): T[] => {
+  const grouped = new Map<string, T[]>();
+  for (const item of items) {
+    const effective = item.category && item.category.trim() !== ''
+      ? item.category
+      : (defaultCategory ?? '');
+    const groupKey = effective || DEFAULT_CATEGORY;
+    if (!grouped.has(groupKey)) {
+      grouped.set(groupKey, []);
     }
-    grouped.get(cat)!.push(item);
+    grouped.get(groupKey)!.push(item);
   }
 
   const sortedCategories = [...grouped.keys()].sort((a, b) => {
@@ -81,13 +79,26 @@ export const formatInventoryCsvText = (
     return a.localeCompare(b, 'ja');
   });
 
-  const lines: string[] = [];
+  const ordered: T[] = [];
   for (const cat of sortedCategories) {
-    for (const item of grouped.get(cat)!) {
-      const stockStr = formatStock(item.stock);
-      const category = item.category && item.category.trim() !== '' ? item.category : undefined;
-      lines.push(category ? `${item.name},${stockStr},${category}` : `${item.name},${stockStr}`);
-    }
+    ordered.push(...grouped.get(cat)!);
+  }
+  return ordered;
+};
+
+export const formatInventoryCsvText = (
+  items: Pick<InventoryItem, 'name' | 'stock' | 'category'>[],
+  defaultCategory?: string
+): string => {
+  const ordered = orderInventoryItemsForCsv(items, defaultCategory);
+
+  const lines: string[] = [];
+  for (const item of ordered) {
+    const stockStr = formatStock(item.stock);
+    const effective = item.category && item.category.trim() !== ''
+      ? item.category
+      : (defaultCategory ?? '');
+    lines.push(effective ? `${item.name},${stockStr},${effective}` : `${item.name},${stockStr}`);
   }
 
   return lines.join('\n');

--- a/src/utils/RemindInventory.ts
+++ b/src/utils/RemindInventory.ts
@@ -36,11 +36,11 @@ const formatInventoryValue = (value: number): string => {
   return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed;
 };
 
-const normalizeLineTokens = (line: string): string[] =>
+const normalizeLineTokens = (line: string, keepEmpty: boolean = false): string[] =>
   line
     .split(',')
     .map((part) => part.trim())
-    .filter((part) => part !== '');
+    .filter((part) => keepEmpty || part !== '');
 
 const toLegacyInventoryItems = (items: RemindInventoryItem[]): LegacyRemindInventoryItem[] =>
   items.filter(isLegacyInventoryItem);
@@ -116,8 +116,8 @@ export const parseInventoryInput = (input: string): InventoryInputItem[] => {
       throw new Error('消費が不足しています');
     }
     const roundedConsume = roundInventoryValue(consume);
-    if (!Number.isFinite(roundedConsume) || roundedConsume <= 0) {
-      throw new Error('消費は0より大きい数値で入力してください');
+    if (!Number.isFinite(roundedConsume) || roundedConsume < 0) {
+      throw new Error('消費は0以上の数値で入力してください');
     }
     const roundedStock = stock === null ? undefined : roundInventoryValue(stock);
     if (roundedStock !== undefined && (!Number.isFinite(roundedStock) || roundedStock < 0)) {
@@ -134,6 +134,51 @@ export const parseInventoryInput = (input: string): InventoryInputItem[] => {
       throw new Error('アイテム名が重複しています');
     }
     seen.add(key);
+  }
+
+  return items;
+};
+
+export const parseCompletionInput = (input: string): Array<{ name: string; consume: number | null }> => {
+  if (!input) {
+    return [];
+  }
+
+  const lines = input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== '');
+
+  const items = lines.map((line) => {
+    const tokens = normalizeLineTokens(line, true);
+    if (tokens.length < 1 || tokens.length > 2) {
+      throw new Error('完了入力の形式が不正です');
+    }
+
+    const name = tokens[0];
+    if (!name) {
+      throw new Error('アイテム名が空です');
+    }
+
+    const consumeToken = tokens[1];
+    if (consumeToken === undefined || consumeToken === '') {
+      return { name, consume: null };
+    }
+
+    const consume = parseNumericToken(consumeToken);
+    if (consume === null || !Number.isFinite(consume) || consume < 0) {
+      throw new Error('消費は0以上の数値で入力してください');
+    }
+
+    return { name, consume };
+  });
+
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.name)) {
+      throw new Error('アイテム名が重複しています');
+    }
+    seen.add(item.name);
   }
 
   return items;

--- a/src/utils/RemindSheetMapper.ts
+++ b/src/utils/RemindSheetMapper.ts
@@ -151,7 +151,7 @@ export function parseInventoryItems(value: string | undefined): RemindTask['inve
       if ('inventoryId' in item) {
         const inventoryId = String(item.inventoryId);
         const consume = Number(item.consume);
-        if (inventoryId.trim() === '' || !Number.isFinite(consume) || consume <= 0) {
+        if (inventoryId.trim() === '' || !Number.isFinite(consume) || consume < 0) {
           return [];
         }
         return [{ inventoryId, consume }];

--- a/tests/buttons/InventoryUpdateButtonHandler.test.ts
+++ b/tests/buttons/InventoryUpdateButtonHandler.test.ts
@@ -18,6 +18,8 @@ describe('InventoryUpdateButtonHandler', () => {
 
   it('ボタン押下時、全在庫をCSV化して一括編集モーダルを表示する', async () => {
     // Given
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
     const items: InventoryItem[] = [
       { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
       { id: 'inventory-2', name: '米', stock: 10.5, category: '食品' }
@@ -45,7 +47,7 @@ describe('InventoryUpdateButtonHandler', () => {
     expect(interaction.update).not.toHaveBeenCalled();
 
     const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
-    expect(modalJson.custom_id).toBe('inventory_update_modal');
+    expect(modalJson.custom_id).toBe('inventory_update_modal:1700000000000');
     expect(modalJson.title).toContain('在庫');
 
     const input = findTextInput(modalJson, 'items');

--- a/tests/buttons/InventoryUpdateButtonHandler.test.ts
+++ b/tests/buttons/InventoryUpdateButtonHandler.test.ts
@@ -55,7 +55,7 @@ describe('InventoryUpdateButtonHandler', () => {
       custom_id: 'items',
       label: '在庫一覧（名前,在庫数,カテゴリ）を編集',
       style: TextInputStyle.Paragraph,
-      required: true,
+      required: false,
       value: '米,10.5,食品\n洗剤,3,日用品'
     }));
   });

--- a/tests/buttons/RemindTaskCompleteButtonHandler.test.ts
+++ b/tests/buttons/RemindTaskCompleteButtonHandler.test.ts
@@ -438,4 +438,222 @@ describe('RemindTaskCompleteButtonHandler', () => {
     expect(mockInventoryMessageManager.createOrUpdateMessage).not.toHaveBeenCalled();
     expect(mockRefreshService.refreshTasksUsingInventory).not.toHaveBeenCalled();
   });
+
+  describe('variable inventory consumption', () => {
+    const baseTaskInput = {
+      id: 'task-1',
+      messageId: 'msg-1',
+      title: '掃除',
+      intervalDays: 7,
+      timeOfDay: '09:00',
+      remindBeforeMinutes: 60,
+      startAt: new Date('2025-12-29T09:00:00+09:00'),
+      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
+      createdAt: new Date('2025-12-29T09:00:00+09:00'),
+      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+    };
+
+    function createMocks(task: ReturnType<typeof createRemindTask>, options?: {
+      linkedInventoryChannelId?: string;
+      inventoryItemsById?: Record<string, { id: string; name: string; stock: number; category: string } | null>;
+    }) {
+      const mockRepository = {
+        findTaskByMessageId: vi.fn().mockResolvedValue(task),
+        updateTask: vi.fn().mockResolvedValue({ success: true })
+      };
+      const mockMessageManager = {
+        updateTaskMessage: vi.fn().mockResolvedValue({ success: true }),
+        sendReminderToThread: vi.fn().mockResolvedValue({ success: true })
+      };
+      const mockMetadataManager = {
+        getChannelMetadata: vi.fn().mockResolvedValue({
+          success: true,
+          metadata: { linkedInventoryChannelId: options?.linkedInventoryChannelId }
+        })
+      };
+      const mockInventoryService = {
+        consumeForTask: vi.fn().mockResolvedValue({
+          kind: 'success',
+          linkedInventoryChannelId: options?.linkedInventoryChannelId
+        }),
+        getById: vi.fn().mockImplementation(async (_channelId: string, inventoryId: string) => {
+          return options?.inventoryItemsById?.[inventoryId] ?? null;
+        })
+      };
+      const mockInventoryRepository = {
+        fetchAll: vi.fn().mockResolvedValue([])
+      };
+      const mockInventoryMessageManager = {
+        createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
+      };
+      const mockRefreshService = {
+        refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
+      };
+      const handler = new RemindTaskCompleteButtonHandler(
+        new Logger(),
+        undefined,
+        mockMetadataManager as any,
+        mockRepository as any,
+        mockMessageManager as any,
+        mockInventoryService as any,
+        mockInventoryRepository as any,
+        mockInventoryMessageManager as any,
+        mockRefreshService as any
+      );
+
+      return {
+        handler,
+        mockRepository,
+        mockInventoryService,
+        mockMetadataManager
+      };
+    }
+
+    function createInteraction() {
+      return {
+        customId: 'remind-task-complete',
+        user: { id: 'user-1', bot: false },
+        channelId: 'channel-1',
+        message: { id: 'msg-1' },
+        client: {} as any,
+        deferReply: vi.fn(),
+        deleteReply: vi.fn(),
+        editReply: vi.fn(),
+        reply: vi.fn(),
+        showModal: vi.fn().mockResolvedValue(undefined)
+      };
+    }
+
+    it('task.inventoryItems に consume === 0 のアイテム（NewRemindInventoryItem 形式）が含まれる場合、interaction.showModal が customId=\'remind-task-complete-modal:{messageId}\' で呼ばれ、consumeForTask は呼ばれない', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: [
+          { inventoryId: 'inventory-1', consume: 0 },
+          { inventoryId: 'inventory-2', consume: 1 }
+        ]
+      });
+      const { handler, mockInventoryService } = createMocks(task, {
+        linkedInventoryChannelId: 'inventory-channel-1',
+        inventoryItemsById: {
+          'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' },
+          'inventory-2': { id: 'inventory-2', name: 'スポンジ', stock: 5, category: '' }
+        }
+      });
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(interaction.showModal).toHaveBeenCalledTimes(1);
+      const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+      expect(modalJson.custom_id).toBe('remind-task-complete-modal:msg-1');
+      expect(modalJson.components[0].components[0].value).toBe('洗剤,\nスポンジ,1');
+      expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+    });
+
+    it('consume > 0 のアイテムだけの場合、従来通り consumeForTask が呼ばれ showModal は呼ばれない', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: [{ inventoryId: 'inventory-1', consume: 1 }]
+      });
+      const { handler, mockInventoryService } = createMocks(task, {
+        linkedInventoryChannelId: 'inventory-channel-1'
+      });
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith('channel-1', task);
+      expect(interaction.showModal).not.toHaveBeenCalled();
+    });
+
+    it('inventoryItems が空の場合、従来通り即時消費フローを通る（showModal が呼ばれない、consumeForTask は呼ばれる）', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: []
+      });
+      const { handler, mockInventoryService } = createMocks(task);
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith('channel-1', task);
+      expect(interaction.showModal).not.toHaveBeenCalled();
+    });
+
+    it('linkedInventoryChannelId が未設定で variable を含む場合、interaction.reply（{ content, flags: [\'Ephemeral\'] }）でエラーメッセージを返し showModal は呼ばれない', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: [{ inventoryId: 'inventory-1', consume: 0 }]
+      });
+      const { handler, mockInventoryService, mockMetadataManager } = createMocks(task, {
+        linkedInventoryChannelId: undefined
+      });
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(mockMetadataManager.getChannelMetadata).toHaveBeenCalledWith('channel-1');
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: '在庫チャンネルが連携されていません',
+        flags: ['Ephemeral']
+      });
+      expect(interaction.showModal).not.toHaveBeenCalled();
+      expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+    });
+
+    it('完了モーダルのタイトル/ラベル/プレースホルダ/required が完了時の文言になっている', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: [{ inventoryId: 'inventory-1', consume: 0 }]
+      });
+      const { handler } = createMocks(task, {
+        linkedInventoryChannelId: 'inventory-channel-1',
+        inventoryItemsById: {
+          'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' }
+        }
+      });
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(interaction.showModal).toHaveBeenCalledTimes(1);
+      const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+      expect(modalJson.title).toBe('完了時の消費数入力');
+      const inputComponent = modalJson.components[0].components[0];
+      expect(inputComponent.label).toBe('消費数(名前,数 の形式 / 空欄でスキップor固定値)');
+      expect(inputComponent.placeholder).toBe('例: 洗剤,2.5');
+      expect(inputComponent.required).toBe(false);
+    });
+
+    it('inventoryService.getById が一部の inventoryId で null を返す場合でも、初期値は "[不明な在庫:<idの先頭8桁>]" のフォールバック表記でモーダルを表示する', async () => {
+      const task = createRemindTask({
+        ...baseTaskInput,
+        inventoryItems: [
+          { inventoryId: 'inventory-1', consume: 0 },
+          { inventoryId: 'missing-inventory-2', consume: 0 }
+        ]
+      });
+      const { handler, mockInventoryService } = createMocks(task, {
+        linkedInventoryChannelId: 'inventory-channel-1',
+        inventoryItemsById: {
+          'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' },
+          'missing-inventory-2': null
+        }
+      });
+      const interaction = createInteraction();
+
+      await handler.handle({ interaction } as any);
+
+      expect(mockInventoryService.getById).toHaveBeenCalledWith('inventory-channel-1', 'inventory-1');
+      expect(mockInventoryService.getById).toHaveBeenCalledWith('inventory-channel-1', 'missing-inventory-2');
+      expect(interaction.showModal).toHaveBeenCalledTimes(1);
+      const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
+      expect(modalJson.custom_id).toBe('remind-task-complete-modal:msg-1');
+      expect(modalJson.components[0].components[0].value).toBe('洗剤,\n[不明な在庫:missing-],');
+      expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/buttons/RemindTaskCompleteButtonHandler.test.ts
+++ b/tests/buttons/RemindTaskCompleteButtonHandler.test.ts
@@ -2,6 +2,40 @@ import { describe, it, expect, vi } from 'vitest';
 import { RemindTaskCompleteButtonHandler } from '../../src/buttons/RemindTaskCompleteButtonHandler';
 import { Logger } from '../../src/utils/logger';
 import { createRemindTask } from '../../src/models/RemindTask';
+import type { InventoryItem } from '../../src/models/InventoryItem';
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+type VariableInventoryMocks = {
+  handler: RemindTaskCompleteButtonHandler;
+  mockRepository: {
+    findTaskByMessageId: MockFn;
+    updateTask: MockFn;
+  };
+  mockInventoryService: {
+    consumeForTask: MockFn;
+    getById: MockFn;
+  };
+  mockInventoryRepository: {
+    fetchAll: MockFn;
+  };
+  mockMetadataManager: {
+    getChannelMetadata: MockFn;
+  };
+};
+
+type RemindTaskCompleteInteractionMock = {
+  customId: string;
+  user: { id: string; bot: boolean };
+  channelId: string;
+  message: { id: string };
+  client: any;
+  deferReply: MockFn;
+  deleteReply: MockFn;
+  editReply: MockFn;
+  reply: MockFn;
+  showModal: MockFn;
+};
 
 describe('RemindTaskCompleteButtonHandler', () => {
   it('completes task and updates message', async () => {
@@ -456,7 +490,7 @@ describe('RemindTaskCompleteButtonHandler', () => {
     function createMocks(task: ReturnType<typeof createRemindTask>, options?: {
       linkedInventoryChannelId?: string;
       inventoryItemsById?: Record<string, { id: string; name: string; stock: number; category: string } | null>;
-    }) {
+    }): VariableInventoryMocks {
       const mockRepository = {
         findTaskByMessageId: vi.fn().mockResolvedValue(task),
         updateTask: vi.fn().mockResolvedValue({ success: true })
@@ -476,12 +510,13 @@ describe('RemindTaskCompleteButtonHandler', () => {
           kind: 'success',
           linkedInventoryChannelId: options?.linkedInventoryChannelId
         }),
-        getById: vi.fn().mockImplementation(async (_channelId: string, inventoryId: string) => {
-          return options?.inventoryItemsById?.[inventoryId] ?? null;
-        })
+        getById: vi.fn()
       };
       const mockInventoryRepository = {
-        fetchAll: vi.fn().mockResolvedValue([])
+        fetchAll: vi.fn().mockImplementation(async () => {
+          return Object.values(options?.inventoryItemsById ?? {})
+            .filter((item): item is InventoryItem => item !== null);
+        })
       };
       const mockInventoryMessageManager = {
         createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
@@ -505,11 +540,12 @@ describe('RemindTaskCompleteButtonHandler', () => {
         handler,
         mockRepository,
         mockInventoryService,
+        mockInventoryRepository,
         mockMetadataManager
       };
     }
 
-    function createInteraction() {
+    function createInteraction(): RemindTaskCompleteInteractionMock {
       return {
         customId: 'remind-task-complete',
         user: { id: 'user-1', bot: false },
@@ -532,7 +568,7 @@ describe('RemindTaskCompleteButtonHandler', () => {
           { inventoryId: 'inventory-2', consume: 1 }
         ]
       });
-      const { handler, mockInventoryService } = createMocks(task, {
+      const { handler, mockInventoryService, mockInventoryRepository } = createMocks(task, {
         linkedInventoryChannelId: 'inventory-channel-1',
         inventoryItemsById: {
           'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' },
@@ -545,8 +581,10 @@ describe('RemindTaskCompleteButtonHandler', () => {
 
       expect(interaction.showModal).toHaveBeenCalledTimes(1);
       const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
-      expect(modalJson.custom_id).toBe('remind-task-complete-modal:msg-1');
+      expect(modalJson.custom_id).toMatch(/^remind-task-complete-modal:msg-1:\d+$/);
       expect(modalJson.components[0].components[0].value).toBe('洗剤,\nスポンジ,1');
+      expect(mockInventoryRepository.fetchAll).toHaveBeenCalledTimes(1);
+      expect(mockInventoryService.getById).not.toHaveBeenCalled();
       expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
       expect(interaction.deferReply).not.toHaveBeenCalled();
     });
@@ -608,7 +646,7 @@ describe('RemindTaskCompleteButtonHandler', () => {
         ...baseTaskInput,
         inventoryItems: [{ inventoryId: 'inventory-1', consume: 0 }]
       });
-      const { handler } = createMocks(task, {
+      const { handler, mockInventoryService, mockInventoryRepository } = createMocks(task, {
         linkedInventoryChannelId: 'inventory-channel-1',
         inventoryItemsById: {
           'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' }
@@ -625,6 +663,8 @@ describe('RemindTaskCompleteButtonHandler', () => {
       expect(inputComponent.label).toBe('消費数(名前,数 の形式 / 空欄でスキップor固定値)');
       expect(inputComponent.placeholder).toBe('例: 洗剤,2.5');
       expect(inputComponent.required).toBe(false);
+      expect(mockInventoryRepository.fetchAll).toHaveBeenCalledTimes(1);
+      expect(mockInventoryService.getById).not.toHaveBeenCalled();
     });
 
     it('inventoryService.getById が一部の inventoryId で null を返す場合でも、初期値は "[不明な在庫:<idの先頭8桁>]" のフォールバック表記でモーダルを表示する', async () => {
@@ -635,7 +675,7 @@ describe('RemindTaskCompleteButtonHandler', () => {
           { inventoryId: 'missing-inventory-2', consume: 0 }
         ]
       });
-      const { handler, mockInventoryService } = createMocks(task, {
+      const { handler, mockInventoryService, mockInventoryRepository } = createMocks(task, {
         linkedInventoryChannelId: 'inventory-channel-1',
         inventoryItemsById: {
           'inventory-1': { id: 'inventory-1', name: '洗剤', stock: 3, category: '' },
@@ -646,12 +686,12 @@ describe('RemindTaskCompleteButtonHandler', () => {
 
       await handler.handle({ interaction } as any);
 
-      expect(mockInventoryService.getById).toHaveBeenCalledWith('inventory-channel-1', 'inventory-1');
-      expect(mockInventoryService.getById).toHaveBeenCalledWith('inventory-channel-1', 'missing-inventory-2');
       expect(interaction.showModal).toHaveBeenCalledTimes(1);
       const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
-      expect(modalJson.custom_id).toBe('remind-task-complete-modal:msg-1');
+      expect(modalJson.custom_id).toMatch(/^remind-task-complete-modal:msg-1:\d+$/);
       expect(modalJson.components[0].components[0].value).toBe('洗剤,\n[不明な在庫:missing-],');
+      expect(mockInventoryRepository.fetchAll).toHaveBeenCalledTimes(1);
+      expect(mockInventoryService.getById).not.toHaveBeenCalled();
       expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
       expect(interaction.deferReply).not.toHaveBeenCalled();
     });

--- a/tests/commands/UpdateInventoryCommand.test.ts
+++ b/tests/commands/UpdateInventoryCommand.test.ts
@@ -70,6 +70,7 @@ describe('UpdateInventoryCommand', () => {
     expect(modalJson.custom_id).toBe('inventory_update_modal');
     expect(modalJson.title).toContain('在庫');
     expect(findTextInput(modalJson, 'items')?.value).toBe('洗剤,3,日用品');
+    expect(findTextInput(modalJson, 'items')?.required).toBe(false);
   });
 
   it('在庫0件でも空の更新モーダルを表示する', async () => {
@@ -86,6 +87,7 @@ describe('UpdateInventoryCommand', () => {
 
     const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
     expect(findTextInput(modalJson, 'items')?.value).toBe('');
+    expect(findTextInput(modalJson, 'items')?.required).toBe(false);
   });
 
   it('コマンドオプションは持たない', () => {

--- a/tests/modals/InventoryUpdateModalHandler.test.ts
+++ b/tests/modals/InventoryUpdateModalHandler.test.ts
@@ -16,6 +16,7 @@ describe('InventoryUpdateModalHandler', () => {
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
+    findReferencingTasks: ReturnType<typeof vi.fn>;
   };
   let repository: {
     fetchAll: ReturnType<typeof vi.fn>;
@@ -51,7 +52,8 @@ describe('InventoryUpdateModalHandler', () => {
     inventoryService = {
       create: vi.fn().mockResolvedValue({ success: true }),
       update: vi.fn().mockResolvedValue({ success: true }),
-      delete: vi.fn().mockResolvedValue(undefined)
+      delete: vi.fn().mockResolvedValue(undefined),
+      findReferencingTasks: vi.fn().mockResolvedValue([])
     };
     repository = {
       fetchAll: vi.fn()
@@ -198,6 +200,127 @@ describe('InventoryUpdateModalHandler', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: expect.stringContaining('1行目')
     });
+  });
+
+  it('参照中の在庫を行位置で名前だけ変えた場合、ID保持のupdateとして扱い delete/create は呼ばない', async () => {
+    // Given: 同じ行で name のみ「米」→「米改」に変更、米はタスクから参照中
+    const items: InventoryItem[] = [
+      { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+      { id: 'inventory-2', name: '米', stock: 10, category: '日用品' }
+    ];
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(items)
+      .mockResolvedValueOnce([
+        { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+        { id: 'inventory-2', name: '米改', stock: 10, category: '日用品' }
+      ]);
+    interaction.fields.getTextInputValue.mockReturnValue('洗剤,3,日用品\n米改,10,日用品');
+    inventoryService.findReferencingTasks.mockImplementation(async (_channelId: string, id: string) => {
+      return id === 'inventory-2' ? [{ channelId: 'task-channel-1', title: '米のタスク' }] : [];
+    });
+
+    // When
+    await handler.handle({ interaction: interaction as any });
+
+    // Then
+    expect(inventoryService.delete).not.toHaveBeenCalled();
+    expect(inventoryService.create).not.toHaveBeenCalled();
+    expect(inventoryService.update).toHaveBeenCalledWith('inventory-channel-1', {
+      id: 'inventory-2',
+      name: '米改',
+      stock: 10,
+      category: '日用品'
+    });
+  });
+
+  it('参照中の在庫の名前と在庫数が同時に変わってもID保持のupdate（rename）として扱う', async () => {
+    // Given
+    const items: InventoryItem[] = [
+      { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+      { id: 'inventory-2', name: '米', stock: 10, category: '日用品' }
+    ];
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(items)
+      .mockResolvedValueOnce([
+        { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+        { id: 'inventory-2', name: '米改', stock: 7, category: '日用品' }
+      ]);
+    interaction.fields.getTextInputValue.mockReturnValue('洗剤,3,日用品\n米改,7,日用品');
+    inventoryService.findReferencingTasks.mockImplementation(async (_channelId: string, id: string) => {
+      return id === 'inventory-2' ? [{ channelId: 'task-channel-1', title: '米のタスク' }] : [];
+    });
+
+    // When
+    await handler.handle({ interaction: interaction as any });
+
+    // Then
+    expect(inventoryService.delete).not.toHaveBeenCalled();
+    expect(inventoryService.create).not.toHaveBeenCalled();
+    expect(inventoryService.update).toHaveBeenCalledWith('inventory-channel-1', {
+      id: 'inventory-2',
+      name: '米改',
+      stock: 7,
+      category: '日用品'
+    });
+  });
+
+  it('参照中の在庫を行位置で名前変更すると delete エラーが起きずに完了する', async () => {
+    // Given: 参照中アイテムの名前のみ変更。rename 扱いになるので delete は呼ばれない
+    const items: InventoryItem[] = [
+      { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+      { id: 'inventory-2', name: '米', stock: 10, category: '日用品' }
+    ];
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(items)
+      .mockResolvedValueOnce([
+        { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+        { id: 'inventory-2', name: '米改', stock: 10, category: '日用品' }
+      ]);
+    interaction.fields.getTextInputValue.mockReturnValue('洗剤,3,日用品\n米改,10,日用品');
+    inventoryService.findReferencingTasks.mockImplementation(async (_channelId: string, id: string) => {
+      return id === 'inventory-2' ? [{ channelId: 'task-channel-1', title: '米のタスク' }] : [];
+    });
+    // 仮に delete が呼ばれたらエラーになる構成（rename 扱いなら呼ばれない）
+    inventoryService.delete.mockRejectedValue(new Error('在庫アイテムを削除できません: 参照中のタスクがあります'));
+
+    // When
+    await handler.handle({ interaction: interaction as any });
+
+    // Then
+    expect(inventoryService.delete).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: '処理が完了しました。' });
+  });
+
+  it('参照中でない在庫の名前変更は通常通り delete + create で処理する', async () => {
+    // Given: 米は参照中でない（findReferencingTasks が空配列）
+    const items: InventoryItem[] = [
+      { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+      { id: 'inventory-2', name: '米', stock: 10, category: '日用品' }
+    ];
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(items)
+      .mockResolvedValueOnce([
+        { id: 'inventory-1', name: '洗剤', stock: 3, category: '日用品' },
+        { id: 'inventory-3', name: '米改', stock: 10, category: '日用品' }
+      ]);
+    interaction.fields.getTextInputValue.mockReturnValue('洗剤,3,日用品\n米改,10,日用品');
+    // findReferencingTasks はデフォルトで空配列を返す
+
+    // When
+    await handler.handle({ interaction: interaction as any });
+
+    // Then
+    expect(inventoryService.create).toHaveBeenCalledWith('inventory-channel-1', {
+      id: expect.any(String),
+      name: '米改',
+      stock: 10,
+      category: '日用品'
+    });
+    expect(inventoryService.delete).toHaveBeenCalledWith('inventory-channel-1', 'inventory-2');
   });
 
   it('customIdはinventory_update_modalとtimestamp付きのみ処理対象にする', () => {

--- a/tests/modals/InventoryUpdateModalHandler.test.ts
+++ b/tests/modals/InventoryUpdateModalHandler.test.ts
@@ -200,9 +200,12 @@ describe('InventoryUpdateModalHandler', () => {
     });
   });
 
-  it('customIdはinventory_update_modalのみ処理対象にする', () => {
+  it('customIdはinventory_update_modalとtimestamp付きのみ処理対象にする', () => {
     expect(handler.shouldHandle({
       interaction: { customId: 'inventory_update_modal' }
+    } as any)).toBe(true);
+    expect(handler.shouldHandle({
+      interaction: { customId: 'inventory_update_modal:1700000000000' }
     } as any)).toBe(true);
     expect(handler.shouldHandle({
       interaction: { customId: 'inventory_update_modal_inventory-1' }

--- a/tests/modals/InventoryUpdateModalHandler.test.ts
+++ b/tests/modals/InventoryUpdateModalHandler.test.ts
@@ -168,6 +168,15 @@ describe('InventoryUpdateModalHandler', () => {
 
   it('deleteが参照タスクありでthrowした場合、途中成功後に該当アイテム名を含むエラー応答を返す', async () => {
     // Given
+    const latestItems: InventoryItem[] = [
+      { id: 'inventory-1', name: '洗剤', stock: 5, category: '日用品' },
+      { id: 'inventory-2', name: '米', stock: 10, category: '食品' },
+      { id: 'inventory-4', name: '追加対象', stock: 2, category: '備品' }
+    ];
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(currentItems)
+      .mockResolvedValueOnce(latestItems);
     inventoryService.delete.mockRejectedValue(new Error('在庫アイテムを削除できません: 参照中のタスクがあります'));
 
     // When
@@ -177,8 +186,16 @@ describe('InventoryUpdateModalHandler', () => {
     expect(inventoryService.create).toHaveBeenCalled();
     expect(inventoryService.update).toHaveBeenCalled();
     expect(inventoryService.delete).toHaveBeenCalledWith('inventory-channel-1', 'inventory-3');
-    expect(inventoryMessageManager.createOrUpdateMessage).not.toHaveBeenCalled();
-    expect(refreshService.refreshTasksUsingInventory).not.toHaveBeenCalled();
+    expect(inventoryMessageManager.createOrUpdateMessage).toHaveBeenCalledWith(
+      'inventory-channel-1',
+      latestItems,
+      '在庫リスト',
+      interaction.client
+    );
+    expect(refreshService.refreshTasksUsingInventory).toHaveBeenCalledWith(
+      'inventory-channel-1',
+      interaction.client
+    );
     expect(interaction.editReply).toHaveBeenCalledWith({
       content: expect.stringContaining('削除対象')
     });
@@ -333,5 +350,38 @@ describe('InventoryUpdateModalHandler', () => {
     expect(handler.shouldHandle({
       interaction: { customId: 'inventory_update_modal_inventory-1' }
     } as any)).toBe(false);
+  });
+
+  it('空文字CSVを送信した場合、参照中以外の全在庫が削除されメッセージが更新される', async () => {
+    // Given
+    interaction.fields.getTextInputValue.mockReturnValue('');
+    repository.fetchAll
+      .mockReset()
+      .mockResolvedValueOnce(currentItems)
+      .mockResolvedValueOnce([]);
+    inventoryService.findReferencingTasks.mockResolvedValue([]);
+
+    // When
+    await handler.handle({ interaction: interaction as any });
+
+    // Then
+    expect(inventoryService.create).not.toHaveBeenCalled();
+    expect(inventoryService.update).not.toHaveBeenCalled();
+    expect(inventoryService.delete).toHaveBeenCalledTimes(3);
+    for (const item of currentItems) {
+      expect(inventoryService.delete).toHaveBeenCalledWith('inventory-channel-1', item.id);
+    }
+    expect(inventoryMessageManager.createOrUpdateMessage).toHaveBeenCalledWith(
+      'inventory-channel-1',
+      [],
+      '在庫リスト',
+      interaction.client
+    );
+    expect(refreshService.refreshTasksUsingInventory).toHaveBeenCalledWith(
+      'inventory-channel-1',
+      interaction.client
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: '処理が完了しました。' });
+    expect(interaction.deleteReply).toHaveBeenCalled();
   });
 });

--- a/tests/modals/RemindTaskCompleteModalHandler.test.ts
+++ b/tests/modals/RemindTaskCompleteModalHandler.test.ts
@@ -1,443 +1,516 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RemindTaskCompleteModalHandler } from '../../src/modals/RemindTaskCompleteModalHandler';
+import { createRemindTask, type RemindInventoryItem, type RemindTask } from '../../src/models/RemindTask';
+import type { InventoryItem } from '../../src/models/InventoryItem';
 import { Logger } from '../../src/utils/logger';
-import { createRemindTask } from '../../src/models/RemindTask';
+
+const taskChannelId = 'task-channel-1';
+const linkedInventoryChannelId = 'inventory-channel-1';
+const messageId = 'message-1';
+const now = new Date('2026-01-05T10:00:00+09:00');
+
+const baseTaskInput = {
+  id: 'task-1',
+  messageId,
+  title: '掃除',
+  intervalDays: 7,
+  timeOfDay: '09:00',
+  remindBeforeMinutes: 60,
+  startAt: new Date('2025-12-29T09:00:00+09:00'),
+  nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
+  createdAt: new Date('2025-12-29T09:00:00+09:00'),
+  updatedAt: new Date('2025-12-29T09:00:00+09:00')
+};
+
+const createTask = (
+  inventoryItems: RemindInventoryItem[],
+  overrides: Partial<Parameters<typeof createRemindTask>[0]> = {}
+): RemindTask => createRemindTask({
+  ...baseTaskInput,
+  inventoryItems,
+  ...overrides
+});
+
+const createInventoryItem = (id: string, name: string): InventoryItem => ({
+  id,
+  name,
+  stock: 10,
+  category: ''
+});
+
+const createInteraction = (input: string) => ({
+  customId: `remind-task-complete-modal:${messageId}`,
+  user: { id: 'user-1' },
+  guild: { id: 'guild-1' },
+  guildId: 'guild-1',
+  channelId: taskChannelId,
+  client: {} as unknown,
+  fields: {
+    getTextInputValue: vi.fn().mockReturnValue(input)
+  },
+  deferReply: vi.fn().mockResolvedValue(undefined),
+  editReply: vi.fn().mockResolvedValue(undefined),
+  deleteReply: vi.fn().mockResolvedValue(undefined)
+});
+
+function createSubject(options: {
+  task: RemindTask;
+  input?: string;
+  linkedInventoryChannelId?: string;
+  inventoryItemsById?: Record<string, InventoryItem | null>;
+  consumeResult?: unknown;
+  inventoryRepositoryItems?: InventoryItem[];
+}) {
+  const linkedChannelId = Object.prototype.hasOwnProperty.call(options, 'linkedInventoryChannelId')
+    ? options.linkedInventoryChannelId
+    : linkedInventoryChannelId;
+  const consumeResult = options.consumeResult ?? {
+    kind: 'success',
+    linkedInventoryChannelId: linkedChannelId
+  };
+  const mockRepository = {
+    findTaskByMessageId: vi.fn().mockResolvedValue(options.task),
+    updateTask: vi.fn().mockResolvedValue({ success: true })
+  };
+  const mockMessageManager = {
+    updateTaskMessage: vi.fn().mockResolvedValue({ success: true }),
+    sendReminderToThread: vi.fn().mockResolvedValue({ success: true })
+  };
+  const mockMetadataManager = {
+    getChannelMetadata: vi.fn().mockResolvedValue({
+      success: true,
+      metadata: { linkedInventoryChannelId: linkedChannelId }
+    })
+  };
+  const mockInventoryService = {
+    consumeForTask: vi.fn().mockResolvedValue(consumeResult),
+    getById: vi.fn().mockImplementation(async (_channelId: string, inventoryId: string) => {
+      if (Object.prototype.hasOwnProperty.call(options.inventoryItemsById ?? {}, inventoryId)) {
+        return options.inventoryItemsById?.[inventoryId] ?? null;
+      }
+      return null;
+    })
+  };
+  const mockInventoryRepository = {
+    fetchAll: vi.fn().mockResolvedValue(options.inventoryRepositoryItems ?? [])
+  };
+  const mockInventoryMessageManager = {
+    createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
+  };
+  const mockRefreshService = {
+    refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
+  };
+  const handler = new RemindTaskCompleteModalHandler(
+    new Logger(),
+    undefined,
+    mockMetadataManager as never,
+    mockRepository as never,
+    mockMessageManager as never,
+    mockInventoryService as never,
+    mockInventoryRepository,
+    mockInventoryMessageManager,
+    mockRefreshService
+  );
+  const interaction = createInteraction(options.input ?? '');
+
+  return {
+    handler,
+    interaction,
+    mockRepository,
+    mockMessageManager,
+    mockMetadataManager,
+    mockInventoryService,
+    mockInventoryRepository,
+    mockInventoryMessageManager,
+    mockRefreshService
+  };
+}
 
 describe('RemindTaskCompleteModalHandler', () => {
-  it('completes task and updates message', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '掃除',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
-    });
-
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue({ kind: 'success' })
-    };
-
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      undefined,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any
-    );
-
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
-
-    await handler.handle({ interaction } as any);
-
-    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith('channel-1', task);
-    expect(mockRepository.updateTask).toHaveBeenCalled();
-    expect(mockMessageManager.updateTaskMessage).toHaveBeenCalled();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
   });
 
-  it('refreshes linked inventory message after consuming inventory', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '掃除',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('fixed のみのタスクで入力どおりに消費する（fixed上書き）', async () => {
+    const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
+    const { handler, interaction, mockInventoryService } = createSubject({
+      task,
+      input: 'A,3',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      }
     });
-    const items = [{ id: 'item-1', name: '洗剤', stock: 2, category: '掃除' }];
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue({ kind: 'success', linkedInventoryChannelId: 'inv-ch-1' })
-    };
-    const mockInventoryRepository = {
-      fetchAll: vi.fn().mockResolvedValue(items)
-    };
-    const mockInventoryMessageManager = {
-      createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockRefreshService = {
-      refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
-    };
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      undefined,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any,
-      mockInventoryRepository as any,
-      mockInventoryMessageManager as any,
-      mockRefreshService as any
-    );
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
 
-    await handler.handle({ interaction } as any);
+    await handler.handle({ interaction } as never);
 
-    expect(mockInventoryRepository.fetchAll).toHaveBeenCalledWith('inv-ch-1');
-    expect(mockInventoryMessageManager.createOrUpdateMessage).toHaveBeenCalledWith(
-      'inv-ch-1',
-      items,
-      '在庫リスト',
-      interaction.client
-    );
-    expect(mockRefreshService.refreshTasksUsingInventory).toHaveBeenCalledWith(
-      'inv-ch-1',
-      interaction.client,
-      { excludeMessageId: 'msg-1' }
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('inventory-items');
+    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'A-id');
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'A-id', consume: 3 }]
+      })
     );
   });
 
-  it('does not refresh inventory message when consumption succeeds without linked inventory channel', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '掃除',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+  it('fixed のみのタスクで入力空欄/0 → 元の consume で消費', async () => {
+    const task = createTask([{ inventoryId: 'A-id', consume: 2 }]);
+    const { handler, interaction, mockInventoryService } = createSubject({
+      task,
+      input: 'A,',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      }
     });
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue({ kind: 'success' })
-    };
-    const mockInventoryRepository = {
-      fetchAll: vi.fn().mockResolvedValue([])
-    };
-    const mockInventoryMessageManager = {
-      createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockRefreshService = {
-      refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
-    };
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      undefined,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any,
-      mockInventoryRepository as any,
-      mockInventoryMessageManager as any,
-      mockRefreshService as any
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'A-id', consume: 2 }]
+      })
     );
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
+  });
 
-    await handler.handle({ interaction } as any);
+  it('variable のみのタスクで入力値で消費、空欄/0はスキップ', async () => {
+    const consumedTask = createTask([{ inventoryId: 'A-id', consume: 0 }]);
+    const consumed = createSubject({
+      task: consumedTask,
+      input: 'A,5',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      }
+    });
 
+    await consumed.handler.handle({ interaction: consumed.interaction } as never);
+
+    expect(consumed.mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'A-id', consume: 5 }]
+      })
+    );
+
+    const skippedTask = createTask([{ inventoryId: 'A-id', consume: 0 }]);
+    const skipped = createSubject({
+      task: skippedTask,
+      input: 'A,',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      }
+    });
+
+    await skipped.handler.handle({ interaction: skipped.interaction } as never);
+
+    expect(skipped.mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expect(skipped.mockRepository.updateTask).toHaveBeenCalled();
+  });
+
+  it('fixed + variable 混在で variable空欄→fixedだけ消費', async () => {
+    const task = createTask([
+      { inventoryId: 'fixedA-id', consume: 1 },
+      { inventoryId: 'variableB-id', consume: 0 }
+    ]);
+    const { handler, interaction, mockInventoryService } = createSubject({
+      task,
+      input: 'fixedA,2\nvariableB,',
+      inventoryItemsById: {
+        'fixedA-id': createInventoryItem('fixedA-id', 'fixedA'),
+        'variableB-id': createInventoryItem('variableB-id', 'variableB')
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'fixedA-id', consume: 2 }]
+      })
+    );
+  });
+
+  it('すべて variable で全行空欄 → consumeForTask は呼ばれず、タスクの nextDueAt だけ更新', async () => {
+    const task = createTask([
+      { inventoryId: 'A-id', consume: 0 },
+      { inventoryId: 'B-id', consume: 0 }
+    ]);
+    const {
+      handler,
+      interaction,
+      mockRepository,
+      mockInventoryService,
+      mockInventoryRepository,
+      mockInventoryMessageManager,
+      mockRefreshService,
+      mockMessageManager
+    } = createSubject({
+      task,
+      input: 'A,\nB,0',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A'),
+        'B-id': createInventoryItem('B-id', 'B')
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expect(mockRepository.updateTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: task.inventoryItems,
+        nextDueAt: new Date('2026-01-12T09:00:00+09:00')
+      })
+    );
     expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
     expect(mockInventoryMessageManager.createOrUpdateMessage).not.toHaveBeenCalled();
     expect(mockRefreshService.refreshTasksUsingInventory).not.toHaveBeenCalled();
+    expect(mockMessageManager.sendReminderToThread).not.toHaveBeenCalled();
   });
 
-  it('blocks completion when inventory is insufficient', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '補充チェック',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      inventoryItems: [{ inventoryId: 'inventory-1', consume: 2 }],
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+  it('在庫不足時、shortage 結果でエラーメッセージを返し、タスクは更新されない', async () => {
+    const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
+    const { handler, interaction, mockInventoryService, mockRepository, mockMessageManager } = createSubject({
+      task,
+      input: 'A,4',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      },
+      consumeResult: {
+        kind: 'shortage',
+        items: [{ inventoryId: 'A-id', name: 'A', required: 4, available: 1 }]
+      }
     });
 
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true }),
-      sendReminderToThread: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMetadataManager = {
-      getChannelMetadata: vi.fn().mockResolvedValue({
-        success: true,
-        metadata: { remindNoticeThreadId: 'thread-1', remindNoticeMessageId: 'notice-msg-1' }
-      })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue({
-        kind: 'shortage',
-        items: [{ inventoryId: 'inventory-1', name: '牛乳', required: 2, available: 1 }]
-      })
-    };
+    await handler.handle({ interaction } as never);
 
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      mockMetadataManager as any,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'A-id', consume: 4 }]
+      })
     );
-
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
-
-    await handler.handle({ interaction } as any);
-
-    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith('channel-1', task);
     expect(mockRepository.updateTask).not.toHaveBeenCalled();
     expect(mockMessageManager.updateTaskMessage).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining('不足している在庫の詳細は以下の通りです')
     }));
-    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('牛乳 1個')
-    }));
-    expect(mockMessageManager.sendReminderToThread).not.toHaveBeenCalled();
   });
 
-  it('notifies thread when inventory becomes insufficient after completion', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '補充チェック',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      inventoryItems: [{ name: '牛乳', stock: 2, consume: 2 }],
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
-    });
-
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true }),
-      sendReminderToThread: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMetadataManager = {
-      getChannelMetadata: vi.fn().mockResolvedValue({
-        success: true,
-        metadata: { remindNoticeThreadId: 'thread-1', remindNoticeMessageId: 'notice-msg-1' }
-      })
-    };
-
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      mockMetadataManager as any,
-      mockRepository as any,
-      mockMessageManager as any
-    );
-
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
-
-    await handler.handle({ interaction } as any);
-
-    expect(mockMessageManager.sendReminderToThread).toHaveBeenCalledWith(
-      'channel-1',
-      'thread-1',
-      'notice-msg-1',
-      '@everyone 補充チェックの次回分に必要な在庫が不足しています。\n不足している在庫の詳細は以下の通りです\n牛乳 2個',
-      interaction.client
-    );
-  });
-
-  it('blocks completion when legacy inventory migration is required', async () => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '補充チェック',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      inventoryItems: [{ name: '牛乳', stock: 3, consume: 1 }],
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
-    });
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue({ kind: 'migration_required' })
-    };
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      undefined,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any
-    );
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
-
-    await handler.handle({ interaction } as any);
-
-    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith('channel-1', task);
-    expect(mockRepository.updateTask).not.toHaveBeenCalled();
-    expect(mockMessageManager.updateTaskMessage).not.toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-      content: expect.stringContaining('在庫移行')
-    }));
-  });
-
-  it.each([
-    {
-      result: {
-        kind: 'shortage',
-        items: [{ inventoryId: 'inventory-1', name: '牛乳', required: 2, available: 1 }]
+  it('入力フォーマット不正時、parseCompletionInput のエラーメッセージを返す', async () => {
+    const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
+    const { handler, interaction, mockInventoryService, mockRepository } = createSubject({
+      task,
+      input: 'A,1,2,3',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
       }
-    },
-    { result: { kind: 'migration_required' } }
-  ])('does not refresh inventory message when consumption is blocked by $result.kind', async ({ result }) => {
-    const task = createRemindTask({
-      id: 'task-1',
-      messageId: 'msg-1',
-      title: '補充チェック',
-      intervalDays: 7,
-      timeOfDay: '09:00',
-      remindBeforeMinutes: 1440,
-      inventoryItems: [{ inventoryId: 'inventory-1', consume: 2 }],
-      startAt: new Date('2025-12-29T09:00:00+09:00'),
-      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
-      createdAt: new Date('2025-12-29T09:00:00+09:00'),
-      updatedAt: new Date('2025-12-29T09:00:00+09:00')
     });
-    const mockRepository = {
-      findTaskByMessageId: vi.fn().mockResolvedValue(task),
-      updateTask: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockMessageManager = {
-      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockInventoryService = {
-      consumeForTask: vi.fn().mockResolvedValue(result)
-    };
-    const mockInventoryRepository = {
-      fetchAll: vi.fn().mockResolvedValue([])
-    };
-    const mockInventoryMessageManager = {
-      createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
-    };
-    const mockRefreshService = {
-      refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
-    };
-    const handler = new RemindTaskCompleteModalHandler(
-      new Logger(),
-      undefined,
-      undefined,
-      mockRepository as any,
-      mockMessageManager as any,
-      mockInventoryService as any,
-      mockInventoryRepository as any,
-      mockInventoryMessageManager as any,
-      mockRefreshService as any
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expect(mockRepository.updateTask).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: '完了入力の形式が不正です'
+    }));
+  });
+
+  it('linkedInventoryChannelId が未設定の場合、エラーメッセージで返す', async () => {
+    const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
+    const { handler, interaction, mockMetadataManager, mockInventoryService, mockRepository } = createSubject({
+      task,
+      input: 'A,1',
+      linkedInventoryChannelId: undefined
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockMetadataManager.getChannelMetadata).toHaveBeenCalledWith(taskChannelId);
+    expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expect(mockRepository.updateTask).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: '在庫チャンネルが連携されていません'
+    }));
+  });
+
+  it('タスクに存在しないアイテム名の行は無視される', async () => {
+    const task = createTask([{ inventoryId: 'real-id', consume: 1 }]);
+    const { handler, interaction, mockInventoryService } = createSubject({
+      task,
+      input: '存在しないアイテム,3\n本物アイテム,1',
+      inventoryItemsById: {
+        'real-id': createInventoryItem('real-id', '本物アイテム')
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'real-id', consume: 1 }]
+      })
     );
-    const interaction = {
-      customId: 'remind-task-complete-modal:msg-1',
-      user: { id: 'user-1' },
-      channelId: 'channel-1',
-      client: {} as any,
-      fields: { getTextInputValue: vi.fn() },
-      deferReply: vi.fn(),
-      editReply: vi.fn(),
-      deleteReply: vi.fn()
-    };
+  });
 
-    await handler.handle({ interaction } as any);
+  it('シート保存時の inventoryItems は元の consume === 0 を維持している', async () => {
+    const originalInventoryItems = [{ inventoryId: 'variable-id', consume: 0 }];
+    const task = createTask(originalInventoryItems);
+    const { handler, interaction, mockRepository, mockInventoryService } = createSubject({
+      task,
+      input: 'Variable,6',
+      inventoryItemsById: {
+        'variable-id': createInventoryItem('variable-id', 'Variable')
+      }
+    });
 
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'variable-id', consume: 6 }]
+      })
+    );
+    expect(mockRepository.updateTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: originalInventoryItems
+      })
+    );
+  });
+
+  it('タスクの nextDueAt/lastDoneAt/overdueNotifyCount などは既存と同じく更新される', async () => {
+    const task = createTask(
+      [{ inventoryId: 'A-id', consume: 1 }],
+      {
+        lastRemindDueAt: new Date('2026-01-05T09:00:00+09:00'),
+        overdueNotifyCount: 3,
+        lastOverdueNotifiedAt: new Date('2026-01-05T09:30:00+09:00')
+      }
+    );
+    const { handler, interaction, mockRepository, mockMessageManager } = createSubject({
+      task,
+      input: 'A,1',
+      inventoryItemsById: {
+        'A-id': createInventoryItem('A-id', 'A')
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockRepository.updateTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        lastDoneAt: now,
+        nextDueAt: new Date('2026-01-12T09:00:00+09:00'),
+        lastRemindDueAt: null,
+        overdueNotifyCount: 0,
+        lastOverdueNotifiedAt: null,
+        updatedAt: now
+      })
+    );
+    expect(mockMessageManager.updateTaskMessage).toHaveBeenCalledWith(
+      taskChannelId,
+      messageId,
+      expect.objectContaining({
+        lastDoneAt: now,
+        nextDueAt: new Date('2026-01-12T09:00:00+09:00')
+      }),
+      interaction.client,
+      now
+    );
+  });
+
+  it('consumeForTask に渡される tempTask.inventoryItems は effectiveConsume > 0 のものだけ含む', async () => {
+    const task = createTask([
+      { inventoryId: 'fixedA-id', consume: 1 },
+      { inventoryId: 'variableB-id', consume: 0 },
+      { inventoryId: 'fixedC-id', consume: 2 }
+    ]);
+    const { handler, interaction, mockInventoryService } = createSubject({
+      task,
+      input: 'fixedA,0\nvariableB,0\nfixedC,4',
+      inventoryItemsById: {
+        'fixedA-id': createInventoryItem('fixedA-id', 'fixedA'),
+        'variableB-id': createInventoryItem('variableB-id', 'variableB'),
+        'fixedC-id': createInventoryItem('fixedC-id', 'fixedC')
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [
+          { inventoryId: 'fixedA-id', consume: 1 },
+          { inventoryId: 'fixedC-id', consume: 4 }
+        ]
+      })
+    );
+  });
+
+  it('fixedアイテムの inventoryService.getById が null を返す場合、tempTask に元の {inventoryId, consume} を含めて consumeForTask に渡し、shortage 結果でエラー応答する', async () => {
+    const task = createTask([{ inventoryId: 'missing-fixed-id', consume: 2 }]);
+    const { handler, interaction, mockInventoryService, mockRepository } = createSubject({
+      task,
+      input: 'A,5',
+      inventoryItemsById: {
+        'missing-fixed-id': null
+      },
+      consumeResult: {
+        kind: 'shortage',
+        items: [{ inventoryId: 'missing-fixed-id', name: 'missing-fixed-id', required: 2, available: 0 }]
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'missing-fixed-id');
+    expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'missing-fixed-id', consume: 2 }]
+      })
+    );
+    expect(mockRepository.updateTask).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('不足している在庫の詳細は以下の通りです')
+    }));
+  });
+
+  it('variableアイテムの inventoryService.getById が null を返す場合、消費スキップしてタスク完了は成功する', async () => {
+    const task = createTask([{ inventoryId: 'missing-variable-id', consume: 0 }]);
+    const { handler, interaction, mockInventoryService, mockRepository, mockInventoryRepository } = createSubject({
+      task,
+      input: 'Variable,5',
+      inventoryItemsById: {
+        'missing-variable-id': null
+      }
+    });
+
+    await handler.handle({ interaction } as never);
+
+    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'missing-variable-id');
+    expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expect(mockRepository.updateTask).toHaveBeenCalledWith(
+      taskChannelId,
+      expect.objectContaining({
+        inventoryItems: task.inventoryItems,
+        lastDoneAt: now
+      })
+    );
     expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
-    expect(mockInventoryMessageManager.createOrUpdateMessage).not.toHaveBeenCalled();
-    expect(mockRefreshService.refreshTasksUsingInventory).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).toHaveBeenCalled();
   });
 });

--- a/tests/modals/RemindTaskCompleteModalHandler.test.ts
+++ b/tests/modals/RemindTaskCompleteModalHandler.test.ts
@@ -9,6 +9,52 @@ const linkedInventoryChannelId = 'inventory-channel-1';
 const messageId = 'message-1';
 const now = new Date('2026-01-05T10:00:00+09:00');
 
+type MockFn = ReturnType<typeof vi.fn>;
+
+type RemindTaskCompleteModalInteractionMock = {
+  customId: string;
+  user: { id: string };
+  guild: { id: string };
+  guildId: string;
+  channelId: string;
+  client: unknown;
+  fields: {
+    getTextInputValue: MockFn;
+  };
+  deferReply: MockFn;
+  editReply: MockFn;
+  deleteReply: MockFn;
+};
+
+type RemindTaskCompleteModalSubject = {
+  handler: RemindTaskCompleteModalHandler;
+  interaction: RemindTaskCompleteModalInteractionMock;
+  mockRepository: {
+    findTaskByMessageId: MockFn;
+    updateTask: MockFn;
+  };
+  mockMessageManager: {
+    updateTaskMessage: MockFn;
+    sendReminderToThread: MockFn;
+  };
+  mockMetadataManager: {
+    getChannelMetadata: MockFn;
+  };
+  mockInventoryService: {
+    consumeForTask: MockFn;
+    getById: MockFn;
+  };
+  mockInventoryRepository: {
+    fetchAll: MockFn;
+  };
+  mockInventoryMessageManager: {
+    createOrUpdateMessage: MockFn;
+  };
+  mockRefreshService: {
+    refreshTasksUsingInventory: MockFn;
+  };
+};
+
 const baseTaskInput = {
   id: 'task-1',
   messageId,
@@ -38,7 +84,7 @@ const createInventoryItem = (id: string, name: string): InventoryItem => ({
   category: ''
 });
 
-const createInteraction = (input: string) => ({
+const createInteraction = (input: string): RemindTaskCompleteModalInteractionMock => ({
   customId: `remind-task-complete-modal:${messageId}`,
   user: { id: 'user-1' },
   guild: { id: 'guild-1' },
@@ -59,8 +105,7 @@ function createSubject(options: {
   linkedInventoryChannelId?: string;
   inventoryItemsById?: Record<string, InventoryItem | null>;
   consumeResult?: unknown;
-  inventoryRepositoryItems?: InventoryItem[];
-}) {
+}): RemindTaskCompleteModalSubject {
   const linkedChannelId = Object.prototype.hasOwnProperty.call(options, 'linkedInventoryChannelId')
     ? options.linkedInventoryChannelId
     : linkedInventoryChannelId;
@@ -92,7 +137,9 @@ function createSubject(options: {
     })
   };
   const mockInventoryRepository = {
-    fetchAll: vi.fn().mockResolvedValue(options.inventoryRepositoryItems ?? [])
+    fetchAll: vi.fn().mockResolvedValue(
+      Object.values(options.inventoryItemsById ?? {}).filter((item): item is InventoryItem => item !== null)
+    )
   };
   const mockInventoryMessageManager = {
     createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
@@ -126,6 +173,14 @@ function createSubject(options: {
   };
 }
 
+const expectInventoryLookupViaFetchAll = (
+  mockInventoryRepository: { fetchAll: ReturnType<typeof vi.fn> },
+  mockInventoryService: { getById: ReturnType<typeof vi.fn> }
+): void => {
+  expect(mockInventoryRepository.fetchAll).toHaveBeenNthCalledWith(1, linkedInventoryChannelId);
+  expect(mockInventoryService.getById).not.toHaveBeenCalled();
+};
+
 describe('RemindTaskCompleteModalHandler', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -139,18 +194,20 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('fixed のみのタスクで入力どおりに消費する（fixed上書き）', async () => {
     const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
-    const { handler, interaction, mockInventoryService } = createSubject({
+    const { handler, interaction, mockRepository, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'A,3',
       inventoryItemsById: {
         'A-id': createInventoryItem('A-id', 'A')
       }
     });
+    interaction.customId = `remind-task-complete-modal:${messageId}:1700000000000`;
 
     await handler.handle({ interaction } as never);
 
+    expect(mockRepository.findTaskByMessageId).toHaveBeenCalledWith(taskChannelId, messageId);
     expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('inventory-items');
-    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'A-id');
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -161,7 +218,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('fixed のみのタスクで入力空欄/0 → 元の consume で消費', async () => {
     const task = createTask([{ inventoryId: 'A-id', consume: 2 }]);
-    const { handler, interaction, mockInventoryService } = createSubject({
+    const { handler, interaction, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'A,',
       inventoryItemsById: {
@@ -171,6 +228,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -191,6 +249,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await consumed.handler.handle({ interaction: consumed.interaction } as never);
 
+    expectInventoryLookupViaFetchAll(consumed.mockInventoryRepository, consumed.mockInventoryService);
     expect(consumed.mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -209,6 +268,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await skipped.handler.handle({ interaction: skipped.interaction } as never);
 
+    expectInventoryLookupViaFetchAll(skipped.mockInventoryRepository, skipped.mockInventoryService);
     expect(skipped.mockInventoryService.consumeForTask).not.toHaveBeenCalled();
     expect(skipped.mockRepository.updateTask).toHaveBeenCalled();
   });
@@ -218,7 +278,7 @@ describe('RemindTaskCompleteModalHandler', () => {
       { inventoryId: 'fixedA-id', consume: 1 },
       { inventoryId: 'variableB-id', consume: 0 }
     ]);
-    const { handler, interaction, mockInventoryService } = createSubject({
+    const { handler, interaction, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'fixedA,2\nvariableB,',
       inventoryItemsById: {
@@ -229,6 +289,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -263,6 +324,7 @@ describe('RemindTaskCompleteModalHandler', () => {
     await handler.handle({ interaction } as never);
 
     expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockRepository.updateTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -270,7 +332,6 @@ describe('RemindTaskCompleteModalHandler', () => {
         nextDueAt: new Date('2026-01-12T09:00:00+09:00')
       })
     );
-    expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
     expect(mockInventoryMessageManager.createOrUpdateMessage).not.toHaveBeenCalled();
     expect(mockRefreshService.refreshTasksUsingInventory).not.toHaveBeenCalled();
     expect(mockMessageManager.sendReminderToThread).not.toHaveBeenCalled();
@@ -278,7 +339,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('在庫不足時、shortage 結果でエラーメッセージを返し、タスクは更新されない', async () => {
     const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
-    const { handler, interaction, mockInventoryService, mockRepository, mockMessageManager } = createSubject({
+    const { handler, interaction, mockInventoryService, mockRepository, mockMessageManager, mockInventoryRepository } = createSubject({
       task,
       input: 'A,4',
       inventoryItemsById: {
@@ -292,6 +353,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -307,7 +369,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('入力フォーマット不正時、parseCompletionInput のエラーメッセージを返す', async () => {
     const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
-    const { handler, interaction, mockInventoryService, mockRepository } = createSubject({
+    const { handler, interaction, mockInventoryService, mockRepository, mockInventoryRepository } = createSubject({
       task,
       input: 'A,1,2,3',
       inventoryItemsById: {
@@ -317,6 +379,8 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
+    expect(mockInventoryService.getById).not.toHaveBeenCalled();
     expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
     expect(mockRepository.updateTask).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -326,7 +390,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('linkedInventoryChannelId が未設定の場合、エラーメッセージで返す', async () => {
     const task = createTask([{ inventoryId: 'A-id', consume: 1 }]);
-    const { handler, interaction, mockMetadataManager, mockInventoryService, mockRepository } = createSubject({
+    const { handler, interaction, mockMetadataManager, mockInventoryService, mockRepository, mockInventoryRepository } = createSubject({
       task,
       input: 'A,1',
       linkedInventoryChannelId: undefined
@@ -335,6 +399,8 @@ describe('RemindTaskCompleteModalHandler', () => {
     await handler.handle({ interaction } as never);
 
     expect(mockMetadataManager.getChannelMetadata).toHaveBeenCalledWith(taskChannelId);
+    expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
+    expect(mockInventoryService.getById).not.toHaveBeenCalled();
     expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
     expect(mockRepository.updateTask).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -344,7 +410,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
   it('タスクに存在しないアイテム名の行は無視される', async () => {
     const task = createTask([{ inventoryId: 'real-id', consume: 1 }]);
-    const { handler, interaction, mockInventoryService } = createSubject({
+    const { handler, interaction, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: '存在しないアイテム,3\n本物アイテム,1',
       inventoryItemsById: {
@@ -354,6 +420,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -365,7 +432,7 @@ describe('RemindTaskCompleteModalHandler', () => {
   it('シート保存時の inventoryItems は元の consume === 0 を維持している', async () => {
     const originalInventoryItems = [{ inventoryId: 'variable-id', consume: 0 }];
     const task = createTask(originalInventoryItems);
-    const { handler, interaction, mockRepository, mockInventoryService } = createSubject({
+    const { handler, interaction, mockRepository, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'Variable,6',
       inventoryItemsById: {
@@ -375,6 +442,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -398,7 +466,7 @@ describe('RemindTaskCompleteModalHandler', () => {
         lastOverdueNotifiedAt: new Date('2026-01-05T09:30:00+09:00')
       }
     );
-    const { handler, interaction, mockRepository, mockMessageManager } = createSubject({
+    const { handler, interaction, mockRepository, mockMessageManager, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'A,1',
       inventoryItemsById: {
@@ -408,6 +476,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockRepository.updateTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -437,7 +506,7 @@ describe('RemindTaskCompleteModalHandler', () => {
       { inventoryId: 'variableB-id', consume: 0 },
       { inventoryId: 'fixedC-id', consume: 2 }
     ]);
-    const { handler, interaction, mockInventoryService } = createSubject({
+    const { handler, interaction, mockInventoryService, mockInventoryRepository } = createSubject({
       task,
       input: 'fixedA,0\nvariableB,0\nfixedC,4',
       inventoryItemsById: {
@@ -449,6 +518,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -460,9 +530,9 @@ describe('RemindTaskCompleteModalHandler', () => {
     );
   });
 
-  it('fixedアイテムの inventoryService.getById が null を返す場合、tempTask に元の {inventoryId, consume} を含めて consumeForTask に渡し、shortage 結果でエラー応答する', async () => {
+  it('fixedアイテムの fetchAll に該当アイテムが存在しない場合、tempTask に元の {inventoryId, consume} を含めて consumeForTask に渡し、shortage 結果でエラー応答する', async () => {
     const task = createTask([{ inventoryId: 'missing-fixed-id', consume: 2 }]);
-    const { handler, interaction, mockInventoryService, mockRepository } = createSubject({
+    const { handler, interaction, mockInventoryService, mockRepository, mockInventoryRepository } = createSubject({
       task,
       input: 'A,5',
       inventoryItemsById: {
@@ -476,7 +546,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
-    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'missing-fixed-id');
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).toHaveBeenCalledWith(
       taskChannelId,
       expect.objectContaining({
@@ -489,7 +559,7 @@ describe('RemindTaskCompleteModalHandler', () => {
     }));
   });
 
-  it('variableアイテムの inventoryService.getById が null を返す場合、消費スキップしてタスク完了は成功する', async () => {
+  it('variableアイテムの fetchAll に該当アイテムが存在しない場合、消費スキップしてタスク完了は成功する', async () => {
     const task = createTask([{ inventoryId: 'missing-variable-id', consume: 0 }]);
     const { handler, interaction, mockInventoryService, mockRepository, mockInventoryRepository } = createSubject({
       task,
@@ -501,7 +571,7 @@ describe('RemindTaskCompleteModalHandler', () => {
 
     await handler.handle({ interaction } as never);
 
-    expect(mockInventoryService.getById).toHaveBeenCalledWith(linkedInventoryChannelId, 'missing-variable-id');
+    expectInventoryLookupViaFetchAll(mockInventoryRepository, mockInventoryService);
     expect(mockInventoryService.consumeForTask).not.toHaveBeenCalled();
     expect(mockRepository.updateTask).toHaveBeenCalledWith(
       taskChannelId,
@@ -510,7 +580,6 @@ describe('RemindTaskCompleteModalHandler', () => {
         lastDoneAt: now
       })
     );
-    expect(mockInventoryRepository.fetchAll).not.toHaveBeenCalled();
     expect(interaction.deleteReply).toHaveBeenCalled();
   });
 });

--- a/tests/modals/RemindTaskInventoryModalHandler.test.ts
+++ b/tests/modals/RemindTaskInventoryModalHandler.test.ts
@@ -192,6 +192,97 @@ describe('RemindTaskInventoryModalHandler', () => {
     );
   });
 
+  it('アイテム名,5,0 のように消費=0 を入力すると variable モードのアイテムとしてタスクに設定できる', async () => {
+    const task = createRemindTask({
+      id: 'task-1',
+      messageId: 'msg-1',
+      title: '補充チェック',
+      intervalDays: 7,
+      timeOfDay: '09:00',
+      remindBeforeMinutes: 1440,
+      startAt: new Date('2025-12-29T09:00:00+09:00'),
+      nextDueAt: new Date('2026-01-05T09:00:00+09:00'),
+      createdAt: new Date('2025-12-29T09:00:00+09:00'),
+      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+    });
+    const inventoryItem = {
+      id: 'inventory-1',
+      name: 'アイテム名',
+      stock: 0,
+      category: ''
+    };
+    const allItems = [
+      {
+        ...inventoryItem,
+        stock: 5
+      }
+    ];
+    const mockRepository = {
+      findTaskByMessageId: vi.fn().mockResolvedValue(task),
+      updateTask: vi.fn().mockResolvedValue({ success: true })
+    };
+    const mockMessageManager = {
+      updateTaskMessage: vi.fn().mockResolvedValue({ success: true })
+    };
+    const mockMetadataManager = {
+      getChannelMetadata: vi.fn().mockResolvedValue({
+        success: true,
+        metadata: { linkedInventoryChannelId: 'inventory-channel-1' }
+      })
+    };
+    const mockInventoryService = {
+      resolveByName: vi.fn().mockResolvedValue(inventoryItem),
+      update: vi.fn().mockResolvedValue({ success: true }),
+      getById: vi.fn()
+    };
+    const mockInventoryRepository = {
+      fetchAll: vi.fn().mockResolvedValue(allItems)
+    };
+    const mockInventoryMessageManager = {
+      createOrUpdateMessage: vi.fn().mockResolvedValue({ success: true })
+    };
+    const refreshService = {
+      refreshTasksUsingInventory: vi.fn().mockResolvedValue(undefined)
+    };
+    const handler = new (RemindTaskInventoryModalHandler as any)(
+      new Logger(),
+      undefined,
+      mockMetadataManager,
+      mockRepository,
+      mockMessageManager,
+      mockInventoryService,
+      mockInventoryRepository,
+      mockInventoryMessageManager,
+      refreshService
+    );
+    const interaction = {
+      customId: 'remind-task-inventory-modal:msg-1',
+      user: { id: 'user-1' },
+      channelId: 'channel-1',
+      client: {} as any,
+      fields: {
+        getTextInputValue: vi.fn().mockReturnValue('アイテム名,5,0')
+      },
+      deferReply: vi.fn(),
+      editReply: vi.fn(),
+      deleteReply: vi.fn()
+    };
+
+    await handler.handle({ interaction } as any);
+
+    expect(mockInventoryService.resolveByName).toHaveBeenCalledWith('inventory-channel-1', 'アイテム名');
+    expect(mockInventoryService.update).toHaveBeenCalledWith('inventory-channel-1', {
+      ...inventoryItem,
+      stock: 5
+    });
+    expect(mockRepository.updateTask).toHaveBeenCalledWith(
+      'channel-1',
+      expect.objectContaining({
+        inventoryItems: [{ inventoryId: 'inventory-1', consume: 0 }]
+      })
+    );
+  });
+
   it('does not update inventory sheet or refresh inventory message when stock is omitted', async () => {
     const task = createRemindTask({
       id: 'task-1',

--- a/tests/modals/RemindTaskInventoryModalHandler.test.ts
+++ b/tests/modals/RemindTaskInventoryModalHandler.test.ts
@@ -64,7 +64,7 @@ describe('RemindTaskInventoryModalHandler', () => {
     );
 
     const interaction = {
-      customId: 'remind-task-inventory-modal:msg-1',
+      customId: 'remind-task-inventory-modal:msg-1:1700000000000',
       user: { id: 'user-1' },
       channelId: 'channel-1',
       client: {} as any,
@@ -78,6 +78,7 @@ describe('RemindTaskInventoryModalHandler', () => {
 
     await handler.handle({ interaction } as any);
 
+    expect(mockRepository.findTaskByMessageId).toHaveBeenCalledWith('channel-1', 'msg-1');
     expect(mockMetadataManager.getChannelMetadata).toHaveBeenCalledWith('channel-1');
     expect(mockInventoryService.resolveByName).toHaveBeenCalledWith('inventory-channel-1', 'フィルター');
     expect(mockRepository.updateTask).toHaveBeenCalledWith(

--- a/tests/modals/RemindTaskUpdateModalHandler.test.ts
+++ b/tests/modals/RemindTaskUpdateModalHandler.test.ts
@@ -35,7 +35,7 @@ describe('RemindTaskUpdateModalHandler', () => {
     );
 
     const interaction = {
-      customId: 'remind-task-update-modal:msg-1',
+      customId: 'remind-task-update-modal:msg-1:1700000000000',
       user: { id: 'user-1' },
       channelId: 'channel-1',
       client: {} as any,
@@ -56,6 +56,7 @@ describe('RemindTaskUpdateModalHandler', () => {
 
     await handler.handle({ interaction } as any);
 
+    expect(mockRepository.findTaskByMessageId).toHaveBeenCalledWith('channel-1', 'msg-1');
     expect(mockRepository.updateTask).toHaveBeenCalled();
     expect(mockMessageManager.updateTaskMessage).toHaveBeenCalled();
   });

--- a/tests/modals/RemindTaskUpdateOverrideModalHandler.test.ts
+++ b/tests/modals/RemindTaskUpdateOverrideModalHandler.test.ts
@@ -36,7 +36,7 @@ describe('RemindTaskUpdateOverrideModalHandler', () => {
     );
 
     const interaction = {
-      customId: 'remind-task-update-override-modal:msg-1',
+      customId: 'remind-task-update-override-modal:msg-1:1700000000000',
       user: { id: 'user-1' },
       channelId: 'channel-1',
       client: {} as any,
@@ -55,6 +55,7 @@ describe('RemindTaskUpdateOverrideModalHandler', () => {
 
     await handler.handle({ interaction } as any);
 
+    expect(mockRepository.findTaskByMessageId).toHaveBeenCalledWith('channel-1', 'msg-1');
     expect(mockRepository.updateTask).toHaveBeenCalled();
     const updatedTask = mockRepository.updateTask.mock.calls[0][1];
     const expectedLastDoneAt = new Date('2025-12-01T09:00:00+09:00');

--- a/tests/models/RemindTask.test.ts
+++ b/tests/models/RemindTask.test.ts
@@ -55,7 +55,7 @@ describe('RemindTask', () => {
     expect(() => validateRemindTask(task)).not.toThrow();
   });
 
-  it('rejects inventory consume value less than or equal to zero', () => {
+  it('rejects legacy inventory consume value less than or equal to zero', () => {
     const task = createRemindTask({
       id: 'task-1',
       title: '棚卸し',
@@ -86,5 +86,41 @@ describe('RemindTask', () => {
     });
 
     expect(() => validateRemindTask(task)).toThrow('interval_daysは1以上である必要があります');
+  });
+});
+
+describe('validateRemindTask inventory consume boundaries', () => {
+  it('consume === 0 の NewRemindInventoryItem が validateRemindTask を通過する（エラーを投げない）', () => {
+    const task = createRemindTask({
+      id: 'task-1',
+      title: '棚卸し',
+      intervalDays: 1,
+      timeOfDay: '10:00',
+      remindBeforeMinutes: 0,
+      inventoryItems: [{ inventoryId: 'inventory-1', consume: 0 }],
+      startAt: new Date('2025-12-29T10:00:00+09:00'),
+      nextDueAt: new Date('2025-12-30T10:00:00+09:00'),
+      createdAt: new Date('2025-12-29T09:00:00+09:00'),
+      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+    });
+
+    expect(() => validateRemindTask(task)).not.toThrow();
+  });
+
+  it('consume < 0 の NewRemindInventoryItem は validateRemindTask でエラー: inventory_itemsの消費数が無効です を投げる', () => {
+    const task = createRemindTask({
+      id: 'task-1',
+      title: '棚卸し',
+      intervalDays: 1,
+      timeOfDay: '10:00',
+      remindBeforeMinutes: 0,
+      inventoryItems: [{ inventoryId: 'inventory-1', consume: -1 }],
+      startAt: new Date('2025-12-29T10:00:00+09:00'),
+      nextDueAt: new Date('2025-12-30T10:00:00+09:00'),
+      createdAt: new Date('2025-12-29T09:00:00+09:00'),
+      updatedAt: new Date('2025-12-29T09:00:00+09:00')
+    });
+
+    expect(() => validateRemindTask(task)).toThrow('inventory_itemsの消費数が無効です');
   });
 });

--- a/tests/selectmenus/RemindTaskUpdateSelectMenuHandler.test.ts
+++ b/tests/selectmenus/RemindTaskUpdateSelectMenuHandler.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Logger } from '../../src/utils/logger';
 import { createRemindTask } from '../../src/models/RemindTask';
 import { RemindTaskUpdateSelectMenuHandler } from '../../src/selectmenus/RemindTaskUpdateSelectMenuHandler';
 
 describe('RemindTaskUpdateSelectMenuHandler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it.each([
-    { value: 'basic', expectedCustomId: 'remind-task-update-modal:msg-1' },
-    { value: 'advanced', expectedCustomId: 'remind-task-update-override-modal:msg-1' },
-    { value: 'inventory', expectedCustomId: 'remind-task-inventory-modal:msg-1' }
+    { value: 'basic', expectedCustomId: 'remind-task-update-modal:msg-1:1700000000000' },
+    { value: 'advanced', expectedCustomId: 'remind-task-update-override-modal:msg-1:1700000000000' },
+    { value: 'inventory', expectedCustomId: 'remind-task-inventory-modal:msg-1:1700000000000' }
   ])('restores task message before showing modal for %s selection', async ({ value, expectedCustomId }) => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
     const task = createRemindTask({
       id: 'task-1',
       messageId: 'msg-1',

--- a/tests/services/GoogleSheetsService-cache.test.ts
+++ b/tests/services/GoogleSheetsService-cache.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GoogleSheetsService } from '../../src/services/GoogleSheetsService';
+import { Config } from '../../src/utils/config';
+
+vi.mock('googleapis', () => ({
+  google: {
+    auth: {
+      GoogleAuth: vi.fn().mockImplementation(() => ({}))
+    },
+    sheets: vi.fn().mockReturnValue({
+      spreadsheets: {
+        get: vi.fn(),
+        batchUpdate: vi.fn(),
+        values: {
+          get: vi.fn(),
+          append: vi.fn(),
+          update: vi.fn(),
+          clear: vi.fn()
+        }
+      }
+    })
+  }
+}));
+
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: vi.fn().mockImplementation(() => ({
+    getClient: vi.fn().mockResolvedValue({})
+  }))
+}));
+
+const resetGoogleSheetsServiceSingleton = (): void => {
+  const instance = (GoogleSheetsService as any).instance;
+  instance?.sheetCache?.clear?.();
+  (GoogleSheetsService as any).instance = undefined;
+};
+
+describe('GoogleSheetsService sheet data cache', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let mockSheets: any;
+  let mockGoogleAuth: any;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+
+    process.env.DISCORD_BOT_TOKEN = 'test-token';
+    process.env.CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_SHEETS_SPREADSHEET_ID = 'test-spreadsheet-id';
+    process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL = 'test@service.account';
+    process.env.GOOGLE_PRIVATE_KEY = 'test-private-key';
+
+    (Config as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
+
+    const { google } = await import('googleapis');
+    const { GoogleAuth } = await import('google-auth-library');
+
+    mockGoogleAuth = GoogleAuth as any;
+    mockSheets = (google.sheets as any)().spreadsheets;
+
+    mockGoogleAuth.mockImplementation(() => ({
+      getClient: vi.fn().mockResolvedValue({})
+    }));
+
+    mockSheets.values.get.mockImplementation(({ range }: { range: string }) => Promise.resolve({
+      data: {
+        values: [[`${range}:fetched:${mockSheets.values.get.mock.calls.length}`]]
+      }
+    }));
+    mockSheets.values.update.mockResolvedValue({ data: {} });
+    mockSheets.values.append.mockResolvedValue({ data: {} });
+    mockSheets.values.clear.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env = originalEnv;
+    (Config as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
+    vi.clearAllMocks();
+  });
+
+  it('同じ sheetName で getSheetDataByName を 2 回呼ぶと、内部の sheets.values.get は 1 回しか呼ばれない（キャッシュヒット）', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    const first = await service.getSheetDataByName('inventory_cache_hit');
+    const second = await service.getSheetDataByName('inventory_cache_hit');
+
+    expect(second).toEqual(first);
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('getSheetDataByName({ skipCache: true }) はキャッシュ存在時でも API を呼ぶ', async () => {
+    const service = GoogleSheetsService.getInstance() as unknown as {
+      getSheetDataByName(sheetName: string, options?: { skipCache?: boolean }): Promise<string[][]>;
+    };
+
+    await service.getSheetDataByName('inventory_skip_cache');
+    await service.getSheetDataByName('inventory_skip_cache', { skipCache: true });
+
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('getSheetDataByName({ skipCache: true }) の結果は cache に保存されず、後続の通常 read で再フェッチする', async () => {
+    const service = GoogleSheetsService.getInstance() as unknown as {
+      sheetCache: Map<string, unknown>;
+      getSheetDataByName(sheetName: string, options?: { skipCache?: boolean }): Promise<string[][]>;
+    };
+    mockSheets.values.get.mockImplementation(() => Promise.resolve({
+      data: {
+        values: mockSheets.values.get.mock.calls.length === 1
+          ? [['skip cache api value']]
+          : [['normal read api value']]
+      }
+    }));
+
+    expect(service.sheetCache.size).toBe(0);
+
+    const skipCacheRead = await service.getSheetDataByName('inventory_skip_cache_no_store', { skipCache: true });
+    const normalRead = await service.getSheetDataByName('inventory_skip_cache_no_store');
+
+    expect(skipCacheRead).toEqual([['skip cache api value']]);
+    expect(normalRead).toEqual([['normal read api value']]);
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('getSheetDataByName({ skipCache: true }) の結果は既存 cache を上書きしない', async () => {
+    const service = GoogleSheetsService.getInstance() as unknown as {
+      getSheetDataByName(sheetName: string, options?: { skipCache?: boolean }): Promise<string[][]>;
+      updateSheetData(sheetName: string, data: unknown[][]): Promise<{ success: boolean }>;
+    };
+    const oldData = [['id', 'name'], ['1', 'old']];
+    const newData = [['id', 'name'], ['1', 'new']];
+    mockSheets.values.get.mockImplementation(() => Promise.resolve({ data: { values: newData } }));
+
+    await service.updateSheetData('inventory_skip_cache_preserve_write_through', oldData);
+    const skipCacheRead = await service.getSheetDataByName('inventory_skip_cache_preserve_write_through', { skipCache: true });
+    const cached = await service.getSheetDataByName('inventory_skip_cache_preserve_write_through');
+
+    expect(skipCacheRead).toEqual(newData);
+    expect(cached).toEqual(oldData);
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('updateSheetData(sheetName, data) 後の getSheetDataByName(sheetName) は書き込み内容をキャッシュから返す', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    await service.updateSheetData('inventory_x', [['id', 'name'], ['1', 'foo']]);
+    const cached = await service.getSheetDataByName('inventory_x');
+
+    expect(cached).toEqual([['id', 'name'], ['1', 'foo']]);
+    expect(mockSheets.values.get).not.toHaveBeenCalled();
+  });
+
+  it('updateSheetData(sheetName, data) の write-through cache は通常 TTL（5秒）経過後も 60秒までは保持される', async () => {
+    vi.useFakeTimers();
+    const service = GoogleSheetsService.getInstance();
+    const writtenData = [['id', 'name'], ['1', 'foo']];
+    const apiData = [['id', 'name'], ['1', 'api']];
+    mockSheets.values.get.mockResolvedValue({ data: { values: apiData } });
+
+    await service.updateSheetData('inventory_write_through_long_ttl', writtenData);
+
+    vi.advanceTimersByTime(5500);
+    const cachedAfterNormalTtl = await service.getSheetDataByName('inventory_write_through_long_ttl');
+
+    expect(cachedAfterNormalTtl).toEqual(writtenData);
+    expect(mockSheets.values.get).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(54501);
+    const refetchedAfterWriteThroughTtl = await service.getSheetDataByName('inventory_write_through_long_ttl');
+
+    expect(refetchedAfterWriteThroughTtl).toEqual(apiData);
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('updateSheetData(sheetName, data) の data が混合型でもキャッシュは string[][] に正規化される', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    await service.updateSheetData('inventory_x', [['id', 'stock'], ['1', 5]]);
+    const cached = await service.getSheetDataByName('inventory_x');
+
+    expect(cached).toEqual([['id', 'stock'], ['1', '5']]);
+    expect(mockSheets.values.get).not.toHaveBeenCalled();
+  });
+
+  it('updateSheetData(sheetName, data, range) は対象 sheetName のキャッシュを invalidate して再フェッチする', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    await service.getSheetDataByName('inventory_range_x');
+    await service.getSheetDataByName('inventory_range_x');
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+
+    await service.updateSheetData('inventory_range_x', [['id', 'name'], ['1', 'foo']], 'inventory_range_x!A1:B2');
+    await service.getSheetDataByName('inventory_range_x');
+
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('appendSheetData(sheetName, ...) でも対象 sheetName のキャッシュが invalidate される', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    await service.getSheetDataByName('inventory_append_target');
+    await service.getSheetDataByName('inventory_append_target');
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+
+    await service.appendSheetData('inventory_append_target', [['appended']]);
+    await service.getSheetDataByName('inventory_append_target');
+
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('TTL（5秒）経過後は getSheetDataByName が再フェッチする', async () => {
+    vi.useFakeTimers();
+    const service = GoogleSheetsService.getInstance();
+
+    await service.getSheetDataByName('inventory_ttl_target');
+    vi.advanceTimersByTime(4999);
+    await service.getSheetDataByName('inventory_ttl_target');
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(2);
+    await service.getSheetDataByName('inventory_ttl_target');
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('同じ sheetName の getSheetDataByName を 3 並列で呼ぶと、in-flight dedupe により API 呼び出しは 1 回にまとまる', async () => {
+    const service = GoogleSheetsService.getInstance();
+    const apiData = [['id', 'name'], ['1', 'deduped']];
+    mockSheets.values.get.mockResolvedValue({ data: { values: apiData } });
+
+    const results = await Promise.all([
+      service.getSheetDataByName('inventory_in_flight_dedupe'),
+      service.getSheetDataByName('inventory_in_flight_dedupe'),
+      service.getSheetDataByName('inventory_in_flight_dedupe')
+    ]);
+
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([apiData, apiData, apiData]);
+  });
+
+  it('getSheetDataByName({ skipCache: true }) の 3 並列 read は in-flight dedupe 対象外で API を 3 回呼ぶ', async () => {
+    const service = GoogleSheetsService.getInstance() as unknown as {
+      getSheetDataByName(sheetName: string, options?: { skipCache?: boolean }): Promise<string[][]>;
+    };
+    const apiData = [['id', 'name'], ['1', 'skip cache']];
+    mockSheets.values.get.mockResolvedValue({ data: { values: apiData } });
+
+    const results = await Promise.all([
+      service.getSheetDataByName('inventory_skip_cache_no_dedupe', { skipCache: true }),
+      service.getSheetDataByName('inventory_skip_cache_no_dedupe', { skipCache: true }),
+      service.getSheetDataByName('inventory_skip_cache_no_dedupe', { skipCache: true })
+    ]);
+
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(3);
+    expect(results).toEqual([apiData, apiData, apiData]);
+  });
+
+  it('in-flight dedupe で取得した結果は cache に保存され、直後の通常 read は API を呼ばない', async () => {
+    const service = GoogleSheetsService.getInstance();
+    const apiData = [['id', 'name'], ['1', 'cached after dedupe']];
+    mockSheets.values.get.mockResolvedValue({ data: { values: apiData } });
+
+    await Promise.all([
+      service.getSheetDataByName('inventory_dedupe_cache_store'),
+      service.getSheetDataByName('inventory_dedupe_cache_store'),
+      service.getSheetDataByName('inventory_dedupe_cache_store')
+    ]);
+
+    mockSheets.values.get.mockClear();
+    const cached = await service.getSheetDataByName('inventory_dedupe_cache_store');
+
+    expect(cached).toEqual(apiData);
+    expect(mockSheets.values.get).not.toHaveBeenCalled();
+  });
+
+  it('異なる sheetName のキャッシュは独立している（A の invalidate で B のキャッシュは保持）', async () => {
+    const service = GoogleSheetsService.getInstance();
+
+    await service.getSheetDataByName('inventory_cache_a');
+    await service.getSheetDataByName('inventory_cache_b');
+    await service.getSheetDataByName('inventory_cache_a');
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+
+    const updatedA = await service.updateSheetData('inventory_cache_a', [['updated a']]);
+    const cachedA = await service.getSheetDataByName('inventory_cache_a');
+    const cachedB = await service.getSheetDataByName('inventory_cache_b');
+
+    expect(updatedA.success).toBe(true);
+    expect(cachedA).toEqual([['updated a']]);
+    expect(cachedB).toEqual([['inventory_cache_b!A:Z:fetched:2']]);
+    expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/services/GoogleSheetsService-error.test.ts
+++ b/tests/services/GoogleSheetsService-error.test.ts
@@ -2,12 +2,18 @@ import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { GoogleSheetsService, GoogleSheetsError, GoogleSheetsErrorType } from '../../src/services/GoogleSheetsService';
 import { Config } from '../../src/utils/config';
 
+const resetGoogleSheetsServiceSingleton = (): void => {
+  const instance = (GoogleSheetsService as any).instance;
+  instance?.sheetCache?.clear?.();
+  (GoogleSheetsService as any).instance = undefined;
+};
+
 describe('GoogleSheetsService Error Handling Tests', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     originalEnv = { ...process.env };
-    (GoogleSheetsService as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
     (Config as any).instance = undefined;
     
     // Discord設定は正常に設定
@@ -17,7 +23,7 @@ describe('GoogleSheetsService Error Handling Tests', () => {
 
   afterEach(() => {
     process.env = originalEnv;
-    (GoogleSheetsService as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
     (Config as any).instance = undefined;
     vi.restoreAllMocks();
   });

--- a/tests/services/GoogleSheetsService.test.ts
+++ b/tests/services/GoogleSheetsService.test.ts
@@ -34,6 +34,12 @@ type GoogleSheetsServiceWithPendingApi = GoogleSheetsService & {
   isKnownSheetName(sheetName: string): boolean;
 };
 
+const resetGoogleSheetsServiceSingleton = (): void => {
+  const instance = (GoogleSheetsService as any).instance;
+  instance?.sheetCache?.clear?.();
+  (GoogleSheetsService as any).instance = undefined;
+};
+
 describe('GoogleSheetsService', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let mockSheets: any;
@@ -51,7 +57,7 @@ describe('GoogleSheetsService', () => {
 
     // シングルトンをリセット
     ;(Config as any).instance = undefined
-    ;(GoogleSheetsService as any).instance = undefined;
+    ;resetGoogleSheetsServiceSingleton();
 
     // モックを取得
     const { google } = await import('googleapis');
@@ -115,7 +121,7 @@ describe('GoogleSheetsService', () => {
   afterEach(() => {
     process.env = originalEnv
     ;(Config as any).instance = undefined
-    ;(GoogleSheetsService as any).instance = undefined;
+    ;resetGoogleSheetsServiceSingleton();
     vi.clearAllMocks();
   });
 
@@ -130,7 +136,7 @@ describe('GoogleSheetsService', () => {
       delete process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
       delete process.env.GOOGLE_PRIVATE_KEY
       ;(Config as any).instance = undefined
-      ;(GoogleSheetsService as any).instance = undefined;
+      ;resetGoogleSheetsServiceSingleton();
 
       expect(() => {
         GoogleSheetsService.getInstance();
@@ -159,7 +165,7 @@ describe('GoogleSheetsService', () => {
 
       process.env.GOOGLE_PRIVATE_KEY = 'invalid-key'
       ;(Config as any).instance = undefined
-      ;(GoogleSheetsService as any).instance = undefined;
+      ;resetGoogleSheetsServiceSingleton();
       
       const service = GoogleSheetsService.getInstance();
       await expect(service.getAuthClient()).rejects.toThrow(GoogleSheetsError);
@@ -213,13 +219,14 @@ describe('GoogleSheetsService', () => {
   });
 
   describe('シートデータ取得', () => {
-    it('キャッシュなしで毎回APIを呼び出す', async () => {
+    it('同じ sheetName はTTL内でキャッシュされAPIは1回だけ呼び出される', async () => {
       const service = GoogleSheetsService.getInstance();
 
-      await service.getSheetDataByName('inventory_x');
-      await service.getSheetDataByName('inventory_x');
+      const first = await service.getSheetDataByName('inventory_x');
+      const second = await service.getSheetDataByName('inventory_x');
 
-      expect(mockSheets.values.get).toHaveBeenCalledTimes(2);
+      expect(second).toEqual(first);
+      expect(mockSheets.values.get).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/services/InventoryMetadataManager.test.ts
+++ b/tests/services/InventoryMetadataManager.test.ts
@@ -155,6 +155,10 @@ describe('InventoryMetadataManager', () => {
 
     // Then
     expect(result.success).toBe(true);
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_metadata',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith('inventory_metadata', [
       metadataHeaders,
       ['channel-1', 'message-3', '更新後在庫リスト', expect.any(String), '飲料', 'thread-3'],

--- a/tests/services/InventoryRepository.test.ts
+++ b/tests/services/InventoryRepository.test.ts
@@ -195,11 +195,15 @@ describe('InventoryRepository', () => {
 
     // Then
     expect(result).toEqual({ success: true });
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_xxx',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'inventory_xxx',
       [
         getInventorySheetHeaders(),
-        toSheetRow(updatedCoffeeBeans),
+        toSheetRow(updatedCoffeeBeans).map(value => String(value)),
         ['item-2', 'Detergent', '1.5', 'daily']
       ]
     );
@@ -221,12 +225,15 @@ describe('InventoryRepository', () => {
       'inventory_channel-1',
       expect.any(Function)
     );
-    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith('inventory_channel-1');
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_channel-1',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'inventory_channel-1',
       [
         getInventorySheetHeaders(),
-        toSheetRow(coffeeBeans)
+        toSheetRow(coffeeBeans).map(value => String(value))
       ]
     );
   });
@@ -244,11 +251,15 @@ describe('InventoryRepository', () => {
 
     // Then
     expect(mockGoogleSheetsService.runWithLock).not.toHaveBeenCalled();
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_channel-1',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'inventory_channel-1',
       [
         getInventorySheetHeaders(),
-        toSheetRow(coffeeBeans)
+        toSheetRow(coffeeBeans).map(value => String(value))
       ]
     );
   });
@@ -266,7 +277,162 @@ describe('InventoryRepository', () => {
     // Then
     expect(result.success).toBe(false);
     expect(result.message).toContain('not found');
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_xxx',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).not.toHaveBeenCalled();
+  });
+
+  describe('bulkUpdate', () => {
+    const sugar: InventoryItem = {
+      id: 'item-3',
+      name: 'Sugar',
+      stock: 4,
+      category: 'food'
+    };
+
+    it('複数のアイテムを 1 回の getSheetDataByName + 1 回の updateSheetData で更新する', async () => {
+      // Given
+      const updatedCoffeeBeans: InventoryItem = { ...coffeeBeans, stock: 3 };
+      const updatedDetergent: InventoryItem = { ...detergent, stock: 2 };
+      const updatedSugar: InventoryItem = { ...sugar, stock: 5 };
+      mockGoogleSheetsService.getSheetDataByName.mockResolvedValue([
+        getInventorySheetHeaders(),
+        ['item-1', 'Coffee beans', '2', 'food'],
+        ['item-2', 'Detergent', '1.5', 'daily'],
+        ['item-3', 'Sugar', '4', 'food']
+      ]);
+      mockGoogleSheetsService.updateSheetData.mockResolvedValue({ success: true });
+
+      // When
+      const result = await repository.bulkUpdate('xxx', [
+        updatedCoffeeBeans,
+        updatedDetergent,
+        updatedSugar
+      ]);
+
+      // Then
+      expect(result).toEqual({ success: true });
+      expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledTimes(1);
+      expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+        'inventory_xxx',
+        { skipCache: true }
+      );
+      expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledTimes(1);
+    });
+
+    it('items の id ごとに対応する行を toSheetRow で書き換えてから updateSheetData する', async () => {
+      // Given
+      const updatedCoffeeBeans: InventoryItem = {
+        ...coffeeBeans,
+        stock: 3,
+        category: 'grocery'
+      };
+      const updatedSugar: InventoryItem = {
+        ...sugar,
+        stock: 5,
+        category: 'seasoning'
+      };
+      mockGoogleSheetsService.getSheetDataByName.mockResolvedValue([
+        getInventorySheetHeaders(),
+        ['item-1', 'Coffee beans', '2', 'food'],
+        ['item-2', 'Detergent', '1.5', 'daily'],
+        ['item-3', 'Sugar', '4', 'food']
+      ]);
+      mockGoogleSheetsService.updateSheetData.mockResolvedValue({ success: true });
+
+      // When
+      await repository.bulkUpdate('xxx', [updatedCoffeeBeans, updatedSugar]);
+
+      // Then
+      expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+        'inventory_xxx',
+        { skipCache: true }
+      );
+      expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
+        'inventory_xxx',
+        [
+          getInventorySheetHeaders(),
+          toSheetRow(updatedCoffeeBeans).map(value => String(value)),
+          ['item-2', 'Detergent', '1.5', 'daily'],
+          toSheetRow(updatedSugar).map(value => String(value))
+        ]
+      );
+    });
+
+    it('items のうち id がシートに存在しないものはスキップして残りを更新する', async () => {
+      // Given
+      const updatedCoffeeBeans: InventoryItem = { ...coffeeBeans, stock: 3 };
+      const missingItem: InventoryItem = {
+        id: 'missing-id',
+        name: 'Missing item',
+        stock: 9,
+        category: 'other'
+      };
+      mockGoogleSheetsService.getSheetDataByName.mockResolvedValue([
+        getInventorySheetHeaders(),
+        ['item-1', 'Coffee beans', '2', 'food'],
+        ['item-2', 'Detergent', '1.5', 'daily']
+      ]);
+      mockGoogleSheetsService.updateSheetData.mockResolvedValue({ success: true });
+
+      // When
+      const result = await repository.bulkUpdate('xxx', [updatedCoffeeBeans, missingItem]);
+
+      // Then
+      expect(result).toEqual({ success: true });
+      expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+        'inventory_xxx',
+        { skipCache: true }
+      );
+      expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
+        'inventory_xxx',
+        [
+          getInventorySheetHeaders(),
+          toSheetRow(updatedCoffeeBeans).map(value => String(value)),
+          ['item-2', 'Detergent', '1.5', 'daily']
+        ]
+      );
+    });
+
+    it('空配列を渡した場合は API を呼ばない', async () => {
+      // When
+      const result = await repository.bulkUpdate('channel-1', []);
+
+      // Then
+      expect(result).toEqual({ success: true });
+      expect(mockGoogleSheetsService.getSheetDataByName).not.toHaveBeenCalled();
+      expect(mockGoogleSheetsService.updateSheetData).not.toHaveBeenCalled();
+      expect(mockGoogleSheetsService.appendSheetData).not.toHaveBeenCalled();
+      expect(mockGoogleSheetsService.runWithLock).not.toHaveBeenCalled();
+    });
+
+    it('useLock: false を指定した場合、runWithLock を呼ばない', async () => {
+      // Given
+      mockGoogleSheetsService.getSheetDataByName.mockResolvedValue([
+        getInventorySheetHeaders(),
+        ['item-1', 'Coffee beans', '2', 'food']
+      ]);
+      mockGoogleSheetsService.updateSheetData.mockResolvedValue({ success: true });
+
+      // When
+      await repository.bulkUpdate('channel-1', [coffeeBeans], { useLock: false });
+
+      // Then
+      expect(mockGoogleSheetsService.runWithLock).not.toHaveBeenCalled();
+      expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+        'inventory_channel-1',
+        { skipCache: true }
+      );
+      expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
+        'inventory_channel-1',
+        [
+          getInventorySheetHeaders(),
+          toSheetRow(coffeeBeans).map(value => String(value))
+        ]
+      );
+    });
   });
 
   it('deletes inventory item by id and rewrites remaining rows', async () => {
@@ -283,6 +449,10 @@ describe('InventoryRepository', () => {
 
     // Then
     expect(result).toEqual({ success: true });
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_xxx',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'inventory_xxx',
       [
@@ -308,7 +478,10 @@ describe('InventoryRepository', () => {
       'inventory_channel-1',
       expect.any(Function)
     );
-    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith('inventory_channel-1');
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'inventory_channel-1',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'inventory_channel-1',
       [getInventorySheetHeaders()]

--- a/tests/services/InventoryService.test.ts
+++ b/tests/services/InventoryService.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:crypto', async importOriginal => ({
   randomUUID: vi.fn(() => '00000000-0000-4000-8000-000000000001')
 }));
 
-type MockInventoryRepository = Pick<InventoryRepository, 'findByName' | 'findById' | 'append' | 'update' | 'delete'>;
+type MockInventoryRepository = Pick<InventoryRepository, 'fetchAll' | 'findByName' | 'findById' | 'append' | 'update' | 'bulkUpdate' | 'delete'>;
 type MockRemindMetadataManager = Pick<RemindMetadataManager, 'findChannelsLinkedToInventory' | 'getChannelMetadata'>;
 type MockRemindTaskRepository = Pick<RemindTaskRepository, 'fetchTasks'>;
 type MockGoogleSheetsService = {
@@ -30,10 +30,12 @@ type ConsumeForTaskResult =
 
 describe('InventoryService', () => {
   let inventoryRepository: {
+    fetchAll: ReturnType<typeof vi.fn>;
     findByName: ReturnType<typeof vi.fn>;
     findById: ReturnType<typeof vi.fn>;
     append: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
+    bulkUpdate: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
   };
   let remindMetadataManager: {
@@ -65,10 +67,12 @@ describe('InventoryService', () => {
 
   beforeEach(() => {
     inventoryRepository = {
+      fetchAll: vi.fn(),
       findByName: vi.fn(),
       findById: vi.fn(),
       append: vi.fn(),
       update: vi.fn(),
+      bulkUpdate: vi.fn().mockResolvedValue({ success: true }),
       delete: vi.fn()
     };
     remindMetadataManager = {
@@ -301,6 +305,7 @@ describe('InventoryService', () => {
       expect(googleSheetsService.runWithLock).not.toHaveBeenCalled();
       expect(inventoryRepository.findById).not.toHaveBeenCalled();
       expect(inventoryRepository.update).not.toHaveBeenCalled();
+      expect(inventoryRepository.bulkUpdate).not.toHaveBeenCalled();
     });
 
     it('returns migration_required without consuming inventory when task includes a legacy inventory item', async () => {
@@ -324,6 +329,7 @@ describe('InventoryService', () => {
       expect(googleSheetsService.runWithLock).not.toHaveBeenCalled();
       expect(inventoryRepository.findById).not.toHaveBeenCalled();
       expect(inventoryRepository.update).not.toHaveBeenCalled();
+      expect(inventoryRepository.bulkUpdate).not.toHaveBeenCalled();
     });
 
     it('returns all shortages without consuming inventory when any item has insufficient stock', async () => {
@@ -332,6 +338,10 @@ describe('InventoryService', () => {
         success: true,
         metadata: { channelId: taskChannelId, linkedInventoryChannelId }
       });
+      inventoryRepository.fetchAll.mockResolvedValue([
+        { ...coffeeBeans, stock: 0.5 },
+        { ...detergent, stock: 0 }
+      ]);
       inventoryRepository.findById
         .mockResolvedValueOnce({ ...coffeeBeans, stock: 0.5 })
         .mockResolvedValueOnce({ ...detergent, stock: 0 });
@@ -353,9 +363,10 @@ describe('InventoryService', () => {
           { inventoryId: 'item-2', name: 'Detergent', required: 0.5, available: 0 }
         ]
       });
-      expect(inventoryRepository.findById).toHaveBeenCalledWith(linkedInventoryChannelId, 'item-1');
-      expect(inventoryRepository.findById).toHaveBeenCalledWith(linkedInventoryChannelId, 'item-2');
+      expect(inventoryRepository.fetchAll).toHaveBeenCalledWith(linkedInventoryChannelId);
+      expect(inventoryRepository.findById).not.toHaveBeenCalled();
       expect(inventoryRepository.update).not.toHaveBeenCalled();
+      expect(inventoryRepository.bulkUpdate).not.toHaveBeenCalled();
     });
 
     it('treats a missing inventory item as shortage with zero available stock', async () => {
@@ -364,6 +375,7 @@ describe('InventoryService', () => {
         success: true,
         metadata: { channelId: taskChannelId, linkedInventoryChannelId }
       });
+      inventoryRepository.fetchAll.mockResolvedValue([]);
       inventoryRepository.findById.mockResolvedValue(null);
       const task = createTask({
         inventoryItems: [{ inventoryId: 'missing-item', consume: 2 }]
@@ -377,8 +389,10 @@ describe('InventoryService', () => {
         kind: 'shortage',
         items: [{ inventoryId: 'missing-item', name: 'missing-item', required: 2, available: 0 }]
       });
-      expect(inventoryRepository.findById).toHaveBeenCalledWith(linkedInventoryChannelId, 'missing-item');
+      expect(inventoryRepository.fetchAll).toHaveBeenCalledWith(linkedInventoryChannelId);
+      expect(inventoryRepository.findById).not.toHaveBeenCalled();
       expect(inventoryRepository.update).not.toHaveBeenCalled();
+      expect(inventoryRepository.bulkUpdate).not.toHaveBeenCalled();
     });
 
     it('updates every inventory item with consumed stock and returns success when all stocks are sufficient', async () => {
@@ -387,10 +401,14 @@ describe('InventoryService', () => {
         success: true,
         metadata: { channelId: taskChannelId, linkedInventoryChannelId }
       });
+      inventoryRepository.fetchAll.mockResolvedValue([
+        { ...coffeeBeans, stock: 3 },
+        { ...detergent, stock: 1.5 }
+      ]);
       inventoryRepository.findById
         .mockResolvedValueOnce({ ...coffeeBeans, stock: 3 })
         .mockResolvedValueOnce({ ...detergent, stock: 1.5 });
-      inventoryRepository.update.mockResolvedValue(successResult);
+      inventoryRepository.bulkUpdate.mockResolvedValue(successResult);
       const task = createTask({
         inventoryItems: [
           { inventoryId: 'item-1', consume: 1 },
@@ -403,14 +421,19 @@ describe('InventoryService', () => {
 
       // Then
       expect(result).toEqual({ kind: 'success', linkedInventoryChannelId });
-      expect(inventoryRepository.update).toHaveBeenCalledWith(linkedInventoryChannelId, {
-        ...coffeeBeans,
-        stock: 2
-      }, { useLock: false });
-      expect(inventoryRepository.update).toHaveBeenCalledWith(linkedInventoryChannelId, {
-        ...detergent,
-        stock: 1
-      }, { useLock: false });
+      expect(inventoryRepository.fetchAll).toHaveBeenCalledTimes(1);
+      expect(inventoryRepository.findById).not.toHaveBeenCalled();
+      expect(inventoryRepository.update).not.toHaveBeenCalled();
+      expect(inventoryRepository.bulkUpdate).toHaveBeenCalledWith(linkedInventoryChannelId, [
+        {
+          ...coffeeBeans,
+          stock: 2
+        },
+        {
+          ...detergent,
+          stock: 1
+        }
+      ], { useLock: false });
     });
 
     it('runs inventory consumption under the linked inventory channel lock', async () => {
@@ -419,8 +442,9 @@ describe('InventoryService', () => {
         success: true,
         metadata: { channelId: taskChannelId, linkedInventoryChannelId }
       });
+      inventoryRepository.fetchAll.mockResolvedValue([{ ...coffeeBeans, stock: 2 }]);
       inventoryRepository.findById.mockResolvedValue({ ...coffeeBeans, stock: 2 });
-      inventoryRepository.update.mockResolvedValue(successResult);
+      inventoryRepository.bulkUpdate.mockResolvedValue(successResult);
       const task = createTask({
         inventoryItems: [{ inventoryId: 'item-1', consume: 1 }]
       });
@@ -433,6 +457,44 @@ describe('InventoryService', () => {
         `inventory_${linkedInventoryChannelId}`,
         expect.any(Function)
       );
+    });
+  });
+
+  describe('checkShortageForTask', () => {
+    const taskChannelId = 'task-channel-1';
+    const linkedInventoryChannelId = 'inventory-channel-1';
+    const checkShortageForTask = (task: RemindTask): Promise<ConsumeForTaskResult> =>
+      (service as unknown as {
+        checkShortageForTask(taskChannelId: string, task: RemindTask): Promise<ConsumeForTaskResult>;
+      }).checkShortageForTask(taskChannelId, task);
+
+    it('returns success without per-item lookup when all stocks are sufficient', async () => {
+      // Given
+      remindMetadataManager.getChannelMetadata.mockResolvedValue({
+        success: true,
+        metadata: { channelId: taskChannelId, linkedInventoryChannelId }
+      });
+      inventoryRepository.fetchAll.mockResolvedValue([
+        { ...coffeeBeans, stock: 3 },
+        { ...detergent, stock: 1.5 }
+      ]);
+      inventoryRepository.findById
+        .mockResolvedValueOnce({ ...coffeeBeans, stock: 3 })
+        .mockResolvedValueOnce({ ...detergent, stock: 1.5 });
+      const task = createTask({
+        inventoryItems: [
+          { inventoryId: 'item-1', consume: 1 },
+          { inventoryId: 'item-2', consume: 0.5 }
+        ]
+      });
+
+      // When
+      const result = await checkShortageForTask(task);
+
+      // Then
+      expect(result).toEqual({ kind: 'success' });
+      expect(inventoryRepository.fetchAll).toHaveBeenCalledTimes(1);
+      expect(inventoryRepository.findById).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/services/MetadataManager.test.ts
+++ b/tests/services/MetadataManager.test.ts
@@ -30,6 +30,12 @@ vi.mock('google-auth-library', () => ({
   }))
 }));
 
+const resetGoogleSheetsServiceSingleton = (): void => {
+  const instance = (GoogleSheetsService as any).instance;
+  instance?.sheetCache?.clear?.();
+  (GoogleSheetsService as any).instance = undefined;
+};
+
 describe('MetadataManager', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let metadataManager: MetadataManager;
@@ -47,7 +53,7 @@ describe('MetadataManager', () => {
 
     // シングルトンをリセット
     (Config as any).instance = undefined;
-    (GoogleSheetsService as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
     (MetadataManager as any).instance = undefined;
 
     // モックを取得
@@ -102,7 +108,7 @@ describe('MetadataManager', () => {
   afterEach(() => {
     process.env = originalEnv;
     (Config as any).instance = undefined;
-    (GoogleSheetsService as any).instance = undefined;
+    resetGoogleSheetsServiceSingleton();
     
     // MetadataManagerのシングルトンと初期化状態をリセット
     const instance = (MetadataManager as any).instance;
@@ -169,31 +175,43 @@ describe('MetadataManager', () => {
         }
       });
 
-      // Act
-      const result = await metadataManager.updateChannelMetadata(testChannelId, testMetadata);
+      const getSheetDataByNameSpy = vi.spyOn(GoogleSheetsService.prototype, 'getSheetDataByName');
+      await metadataManager.getOrCreateMetadataSheet();
+      getSheetDataByNameSpy.mockClear();
 
-      // Assert
-      expect(result.success).toBe(true);
-      expect(result.metadata).toBeDefined();
-      expect(result.metadata!.operationLogThreadId).toBe(testOperationLogThreadId);
-      
-      // updateが6列で呼ばれることを確認
-      expect(mockSheets.values.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          range: 'A2:F2',
-          valueInputOption: 'RAW',
-          resource: {
-            values: [[
-              testChannelId,
-              'msg123',
-              'テストリスト',
-              expect.any(String), // 日付文字列
-              'general',
-              testOperationLogThreadId
-            ]]
-          }
-        })
-      );
+      try {
+        // Act
+        const result = await metadataManager.updateChannelMetadata(testChannelId, testMetadata);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.metadata).toBeDefined();
+        expect(result.metadata!.operationLogThreadId).toBe(testOperationLogThreadId);
+        expect(getSheetDataByNameSpy).toHaveBeenCalledWith(
+          'metadata',
+          { skipCache: true }
+        );
+
+        // updateが6列で呼ばれることを確認
+        expect(mockSheets.values.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            range: 'A2:F2',
+            valueInputOption: 'RAW',
+            resource: {
+              values: [[
+                testChannelId,
+                'msg123',
+                'テストリスト',
+                expect.any(String), // 日付文字列
+                'general',
+                testOperationLogThreadId
+              ]]
+            }
+          })
+        );
+      } finally {
+        getSheetDataByNameSpy.mockRestore();
+      }
     });
 
     it('createChannelMetadata() が新フィールドを保存できる', async () => {
@@ -298,7 +316,7 @@ describe('MetadataManager', () => {
       
       // インスタンスとモックをクリア
       (Config as any).instance = undefined;
-      (GoogleSheetsService as any).instance = undefined;
+      resetGoogleSheetsServiceSingleton();
       (MetadataManager as any).instance = undefined;
       vi.clearAllMocks();
       
@@ -337,7 +355,7 @@ describe('MetadataManager', () => {
 
       // Act - Configシングルトンをリセット
       (Config as any).instance = undefined;
-      (GoogleSheetsService as any).instance = undefined;
+      resetGoogleSheetsServiceSingleton();
       (MetadataManager as any).instance = undefined;
 
       const newInstance = MetadataManager.getInstance();
@@ -427,31 +445,43 @@ describe('MetadataManager', () => {
         }
       });
 
-      // Act
-      const result = await metadataManager.updateChannelMetadata(testChannelId, testMetadata);
+      const getSheetDataByNameSpy = vi.spyOn(GoogleSheetsService.prototype, 'getSheetDataByName');
+      await metadataManager.getOrCreateMetadataSheet();
+      getSheetDataByNameSpy.mockClear();
 
-      // Assert
-      expect(result.success).toBe(true);
-      expect(result.metadata).toBeDefined();
-      expect(result.metadata!.operationLogThreadId).toBeUndefined();
-      
-      // updateが6列で呼ばれることを確認（6列目は空文字列またはundefined）
-      expect(mockSheets.values.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          range: 'A2:F2',
-          valueInputOption: 'RAW',
-          resource: {
-            values: [[
-              testChannelId,
-              'msg123',
-              'テストリスト',
-              expect.any(String), // 日付文字列
-              'general',
-              ''
-            ]]
-          }
-        })
-      );
+      try {
+        // Act
+        const result = await metadataManager.updateChannelMetadata(testChannelId, testMetadata);
+
+        // Assert
+        expect(result.success).toBe(true);
+        expect(result.metadata).toBeDefined();
+        expect(result.metadata!.operationLogThreadId).toBeUndefined();
+        expect(getSheetDataByNameSpy).toHaveBeenCalledWith(
+          'metadata',
+          { skipCache: true }
+        );
+
+        // updateが6列で呼ばれることを確認（6列目は空文字列またはundefined）
+        expect(mockSheets.values.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            range: 'A2:F2',
+            valueInputOption: 'RAW',
+            resource: {
+              values: [[
+                testChannelId,
+                'msg123',
+                'テストリスト',
+                expect.any(String), // 日付文字列
+                'general',
+                ''
+              ]]
+            }
+          })
+        );
+      } finally {
+        getSheetDataByNameSpy.mockRestore();
+      }
     });
 
     it('5列から6列への移行時にヘッダー更新が正しく動作する', async () => {

--- a/tests/services/RemindMetadataManager.test.ts
+++ b/tests/services/RemindMetadataManager.test.ts
@@ -93,6 +93,10 @@ describe('RemindMetadataManager', () => {
     });
 
     expect(result.success).toBe(true);
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'remind_metadata',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalled();
   });
 
@@ -168,6 +172,10 @@ describe('RemindMetadataManager', () => {
     // Then
     expect(result.success).toBe(true);
     expect((result.metadata as any)?.linkedInventoryChannelId).toBe('inventory-channel-2');
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'remind_metadata',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'remind_metadata',
       expect.arrayContaining([
@@ -201,6 +209,10 @@ describe('RemindMetadataManager', () => {
     // Then
     expect(result.success).toBe(true);
     expect((result.metadata as any)?.linkedInventoryChannelId).toBeUndefined();
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'remind_metadata',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalledWith(
       'remind_metadata',
       expect.arrayContaining([

--- a/tests/services/RemindTaskRepository.test.ts
+++ b/tests/services/RemindTaskRepository.test.ts
@@ -96,6 +96,10 @@ describe('RemindTaskRepository', () => {
     const result = await repository.updateTask('123', task);
 
     expect(result.success).toBe(true);
+    expect(mockGoogleSheetsService.getSheetDataByName).toHaveBeenCalledWith(
+      'remind_list_123',
+      { skipCache: true }
+    );
     expect(mockGoogleSheetsService.updateSheetData).toHaveBeenCalled();
   });
 

--- a/tests/utils/RemindInventory.test.ts
+++ b/tests/utils/RemindInventory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseInventoryInput,
+  parseCompletionInput,
   consumeInventory,
   getInsufficientInventoryItems,
   formatInventoryShortageNotice,
@@ -24,9 +25,21 @@ describe('RemindInventory', () => {
     ]);
   });
 
+  it('allows zero consume with stock and consume columns', () => {
+    expect(parseInventoryInput('アイテム名,5,0')).toEqual([
+      { name: 'アイテム名', stock: 5, consume: 0 }
+    ]);
+  });
+
   it('keeps two-column inventory input backward compatible', () => {
     expect(parseInventoryInput('米,1')).toEqual([
       { name: '米', stock: undefined, consume: 1 }
+    ]);
+  });
+
+  it('allows zero consume with two-column inventory input', () => {
+    expect(parseInventoryInput('アイテム名,0')).toEqual([
+      { name: 'アイテム名', stock: undefined, consume: 0 }
     ]);
   });
 
@@ -56,8 +69,8 @@ describe('RemindInventory', () => {
     ]);
   });
 
-  it('rejects when rounded consume becomes zero', () => {
-    expect(() => parseInventoryInput('フィルター,0.04')).toThrow('消費は0より大きい数値で入力してください');
+  it('rejects negative consume values', () => {
+    expect(() => parseInventoryInput('アイテム名,-1')).toThrow();
   });
 
   it('rejects invalid inventory format', () => {
@@ -108,5 +121,59 @@ describe('RemindInventory', () => {
     expect(formatInventoryShortageNotice(items)).toBe(
       '不足している在庫の詳細は以下の通りです\n牛乳 0.3個\n卵 3個'
     );
+  });
+
+  describe('parseCompletionInput', () => {
+    it('parses completion input lines with consume values', () => {
+      expect(parseCompletionInput('アイテムA,3\nアイテムB,1.5')).toEqual([
+        { name: 'アイテムA', consume: 3 },
+        { name: 'アイテムB', consume: 1.5 }
+      ]);
+    });
+
+    it('parses omitted consume as null when the consume column is empty', () => {
+      expect(parseCompletionInput('アイテムA,')).toEqual([
+        { name: 'アイテムA', consume: null }
+      ]);
+    });
+
+    it('allows zero consume values', () => {
+      expect(parseCompletionInput('アイテムA,0')).toEqual([
+        { name: 'アイテムA', consume: 0 }
+      ]);
+    });
+
+    it('skips blank and whitespace-only lines', () => {
+      expect(parseCompletionInput('\n  \nアイテムA,3\n\t\nアイテムB,1')).toEqual([
+        { name: 'アイテムA', consume: 3 },
+        { name: 'アイテムB', consume: 1 }
+      ]);
+    });
+
+    it('rejects input with three or more tokens', () => {
+      expect(() => parseCompletionInput('A,1,2')).toThrow();
+    });
+
+    it('allows item-name-only lines and parses consume as null', () => {
+      expect(parseCompletionInput('アイテムA')).toEqual([
+        { name: 'アイテムA', consume: null }
+      ]);
+    });
+
+    it('rejects duplicate item names', () => {
+      expect(() => parseCompletionInput('A,1\nA,2')).toThrow();
+    });
+
+    it('rejects negative consume values', () => {
+      expect(() => parseCompletionInput('A,-1')).toThrow();
+    });
+
+    it('rejects invalid consume numbers', () => {
+      expect(() => parseCompletionInput('A,abc')).toThrow();
+    });
+
+    it('returns an empty array for empty input', () => {
+      expect(parseCompletionInput('')).toEqual([]);
+    });
   });
 });

--- a/tests/utils/RemindSheetMapper.test.ts
+++ b/tests/utils/RemindSheetMapper.test.ts
@@ -170,6 +170,40 @@ describe('RemindInventoryItem union parsing', () => {
     expect(items.every(isNewInventoryItem)).toBe(true);
   });
 
+  it('parses new format inventory items with zero consume from JSON', () => {
+    // Given
+    const json = JSON.stringify([{ inventoryId: 'inventory-1', consume: 0 }]);
+
+    // When
+    const items: RemindInventoryItem[] = parseInventoryItems(json);
+
+    // Then
+    expect(items).toContainEqual<NewRemindInventoryItem>({
+      inventoryId: 'inventory-1',
+      consume: 0
+    });
+  });
+
+  it('filters new format inventory items with negative consume from JSON', () => {
+    // Given
+    const json = JSON.stringify([
+      { inventoryId: 'inventory-1', consume: -1 },
+      { inventoryId: 'inventory-2', consume: 1 }
+    ]);
+
+    // When
+    const items: RemindInventoryItem[] = parseInventoryItems(json);
+
+    // Then
+    expect(items).not.toContainEqual<NewRemindInventoryItem>({
+      inventoryId: 'inventory-1',
+      consume: -1
+    });
+    expect(items).toEqual<NewRemindInventoryItem[]>([
+      { inventoryId: 'inventory-2', consume: 1 }
+    ]);
+  });
+
   it('parses legacy format inventory items from JSON', () => {
     // Given
     const json = JSON.stringify([{ name: '洗剤', stock: 3, consume: 1 }]);


### PR DESCRIPTION
## Summary

- 繰り返しタスクの在庫アイテムに `consume=0` を `variable` モードのマーカーとして導入し、完了時に専用モーダルで消費数を任意入力できるようにする (closes #30)
- 在庫一括更新の挙動を改善: 行位置ベースで current/edited を対応付けてタスク参照中アイテムをリネームとして扱い、削除エラー時も部分成功を反映、空送信での全削除を許可
- 在庫処理のパフォーマンスとキャッシュ整合性を強化: `GoogleSheetsService` に5秒TTLキャッシュ + write-through(60秒) + in-flight dedupe、`consumeForTask` のN+1を `bulkUpdate` + Map 検索で解消、read-modify-write 経路に `skipCache` で lost update を回避

## Test plan

- [ ] `npm run check` で型チェックとリントが通ることを確認
- [ ] `npm test` で全テストがパスすることを確認
- [ ] `variable` 在庫を含む繰り返しタスク完了時、モーダルで消費数を任意入力できることを動作確認
- [ ] `fixed` 在庫はモーダルで既存値が表示され、空欄でスキップ・値入力で上書き消費されることを確認
- [ ] 在庫一括更新でアイテム名をリネームしてもタスク参照が維持されることを確認
- [ ] 在庫一括更新を空送信した場合に全在庫が削除されることを確認
- [ ] 連続操作時にキャッシュが整合し、lost update や stale read が発生しないことを確認