### PR TITLE
feat: 在庫追加モーダルをリスト管理と同形式に変更

### DIFF
--- a/src/buttons/InventoryAddButtonHandler.ts
+++ b/src/buttons/InventoryAddButtonHandler.ts
@@ -36,16 +36,28 @@ export class InventoryAddButtonHandler extends BaseButtonHandler {
       .setCustomId('inventory_add_modal')
       .setTitle('在庫を追加');
 
+    const categoryInput = new TextInputBuilder()
+      .setCustomId('category')
+      .setLabel('カテゴリー（省略可）')
+      .setStyle(TextInputStyle.Short)
+      .setPlaceholder('例: 食料品、日用品')
+      .setRequired(false)
+      .setMaxLength(50);
+
     const itemsInput = new TextInputBuilder()
       .setCustomId('items')
-      .setLabel('名前,在庫数,カテゴリ（1行に1つ）')
+      .setLabel('名前,在庫数（1行に1つ）')
       .setStyle(TextInputStyle.Paragraph)
-      .setPlaceholder('例:\n洗剤,5,日用品\nパン,3,食料品')
+      .setPlaceholder('例:\n洗剤,5\nパン,3')
       .setRequired(true)
       .setMaxLength(4000);
 
-    return modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(itemsInput)
-    );
+    const categoryRow = new ActionRowBuilder<TextInputBuilder>()
+      .addComponents(categoryInput);
+
+    const itemsRow = new ActionRowBuilder<TextInputBuilder>()
+      .addComponents(itemsInput);
+
+    return modal.addComponents(categoryRow, itemsRow);
   }
 }

--- a/src/modals/InventoryAddModalHandler.ts
+++ b/src/modals/InventoryAddModalHandler.ts
@@ -7,7 +7,7 @@ import { InventoryMetadataManager } from '../services/InventoryMetadataManager';
 import { InventoryMessageManager } from '../services/InventoryMessageManager';
 import { InventoryRepository } from '../services/InventoryRepository';
 import { InventoryService } from '../services/InventoryService';
-import { parseInventoryCsvText } from '../utils/InventoryParser';
+import { parseInventoryAddCsvText } from '../utils/InventoryParser';
 import { Logger } from '../utils/logger';
 
 interface InventoryServicePort {
@@ -59,9 +59,10 @@ export class InventoryAddModalHandler extends BaseModalHandler {
     }
 
     const itemsText = context.interaction.fields.getTextInputValue('items');
-    let parsed;
+    const categoryInput = context.interaction.fields.getTextInputValue('category');
+    let parsed: { name: string; stock: number }[];
     try {
-      parsed = parseInventoryCsvText(itemsText);
+      parsed = parseInventoryAddCsvText(itemsText);
     } catch (error) {
       return {
         success: false,
@@ -73,8 +74,10 @@ export class InventoryAddModalHandler extends BaseModalHandler {
       return { success: false, message: '少なくとも1件入力してください' };
     }
 
+    const trimmed = (categoryInput ?? '').trim();
     const metadata = await this.metadataReader.getChannelMetadata(channelId);
     const defaultCategory = metadata?.defaultCategory ?? '';
+    const unifiedCategory = trimmed !== '' ? trimmed : defaultCategory;
     const skipped: string[] = [];
 
     for (const item of parsed) {
@@ -82,7 +85,7 @@ export class InventoryAddModalHandler extends BaseModalHandler {
         id: randomUUID(),
         name: item.name,
         stock: item.stock,
-        category: item.category ?? defaultCategory
+        category: unifiedCategory
       });
 
       if (!result.success) {

--- a/src/utils/InventoryParser.ts
+++ b/src/utils/InventoryParser.ts
@@ -7,6 +7,11 @@ export interface InventoryCsvItem {
   category?: string;
 }
 
+export interface InventoryAddCsvItem {
+  name: string;
+  stock: number;
+}
+
 const roundStock = (value: number): number => Math.round(value * 10) / 10;
 
 const formatStock = (value: number): string => {
@@ -15,15 +20,39 @@ const formatStock = (value: number): string => {
   return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed;
 };
 
-export const parseInventoryCsvText = (text: string): InventoryCsvItem[] => {
+const splitCsvLines = (text: string): string[] => {
   if (!text) {
     return [];
   }
 
-  const lines = text
+  return text
     .split(/\r?\n/)
     .map(line => line.trim())
     .filter(line => line !== '');
+};
+
+const parseNameAndStock = (name: string, stockText: string, index: number): InventoryAddCsvItem => {
+  if (!name) {
+    throw new Error(`${index + 1}行目: 名前が空です`);
+  }
+
+  if (!/^-?\d+(?:\.\d+)?$/.test(stockText)) {
+    throw new Error(`${index + 1}行目: 在庫数は数値で入力してください`);
+  }
+
+  const stock = roundStock(Number(stockText));
+  if (stock < 0) {
+    throw new Error(`${index + 1}行目: 在庫数は0以上で入力してください`);
+  }
+
+  return {
+    name,
+    stock,
+  };
+};
+
+export const parseInventoryCsvText = (text: string): InventoryCsvItem[] => {
+  const lines = splitCsvLines(text);
 
   return lines.map((line, index) => {
     const tokens = line.split(',').map(token => token.trim());
@@ -32,24 +61,26 @@ export const parseInventoryCsvText = (text: string): InventoryCsvItem[] => {
     }
 
     const [name, stockText, categoryRaw] = tokens;
-    if (!name) {
-      throw new Error(`${index + 1}行目: 名前が空です`);
-    }
-
-    if (!/^-?\d+(?:\.\d+)?$/.test(stockText)) {
-      throw new Error(`${index + 1}行目: 在庫数は数値で入力してください`);
-    }
-
-    const stock = roundStock(Number(stockText));
-    if (stock < 0) {
-      throw new Error(`${index + 1}行目: 在庫数は0以上で入力してください`);
-    }
+    const item = parseNameAndStock(name, stockText, index);
 
     return {
-      name,
-      stock,
+      ...item,
       category: categoryRaw === undefined || categoryRaw === '' ? undefined : categoryRaw,
     };
+  });
+};
+
+export const parseInventoryAddCsvText = (text: string): InventoryAddCsvItem[] => {
+  const lines = splitCsvLines(text);
+
+  return lines.map((line, index) => {
+    const tokens = line.split(',').map(token => token.trim());
+    if (tokens.length !== 2) {
+      throw new Error(`${index + 1}行目: 「名前,在庫数」の形式で入力してください`);
+    }
+
+    const [name, stockText] = tokens;
+    return parseNameAndStock(name, stockText, index);
   });
 };
 

--- a/tests/buttons/InventoryAddButtonHandler.test.ts
+++ b/tests/buttons/InventoryAddButtonHandler.test.ts
@@ -23,12 +23,22 @@ describe('InventoryAddButtonHandler', () => {
     const modalJson = interaction.showModal.mock.calls[0][0].toJSON();
     expect(modalJson.custom_id).toBe('inventory_add_modal');
     expect(modalJson.title).toBe('在庫を追加');
-    expect(modalJson.components).toHaveLength(1);
-    const input = modalJson.components[0].components[0];
-    expect(input.custom_id).toBe('items');
-    expect(input.label).toBe('名前,在庫数,カテゴリ（1行に1つ）');
-    expect(input.style).toBe(TextInputStyle.Paragraph);
-    expect(input.required).toBe(true);
-    expect(input.placeholder).toBe('例:\n洗剤,5,日用品\nパン,3,食料品');
+    expect(modalJson.components).toHaveLength(2);
+
+    const categoryInput = modalJson.components[0].components[0];
+    expect(categoryInput.custom_id).toBe('category');
+    expect(categoryInput.label).toBe('カテゴリー（省略可）');
+    expect(categoryInput.style).toBe(TextInputStyle.Short);
+    expect(categoryInput.required).toBe(false);
+    expect(categoryInput.max_length).toBe(50);
+    expect(categoryInput.placeholder).toBe('例: 食料品、日用品');
+
+    const itemsInput = modalJson.components[1].components[0];
+    expect(itemsInput.custom_id).toBe('items');
+    expect(itemsInput.label).toBe('名前,在庫数（1行に1つ）');
+    expect(itemsInput.style).toBe(TextInputStyle.Paragraph);
+    expect(itemsInput.required).toBe(true);
+    expect(itemsInput.max_length).toBe(4000);
+    expect(itemsInput.placeholder).toBe('例:\n洗剤,5\nパン,3');
   });
 });

--- a/tests/modals/InventoryAddModalHandler.test.ts
+++ b/tests/modals/InventoryAddModalHandler.test.ts
@@ -38,6 +38,14 @@ describe('InventoryAddModalHandler', () => {
   let context: ModalHandlerContext;
   let handler: InventoryAddModalHandler;
 
+  const mockModalFields = (items: string, category: string): void => {
+    interaction.fields.getTextInputValue = vi.fn((fieldId: string) => {
+      if (fieldId === 'items') return items;
+      if (fieldId === 'category') return category;
+      return '';
+    });
+  };
+
   beforeEach(() => {
     logger = new MockLogger();
     inventoryService = {
@@ -60,7 +68,8 @@ describe('InventoryAddModalHandler', () => {
       client: { channels: { fetch: vi.fn() } },
       fields: {
         getTextInputValue: vi.fn((fieldId: string) => {
-          if (fieldId === 'items') return '洗剤,5,日用品\nパン,3,食料品';
+          if (fieldId === 'items') return '洗剤,5\nパン,3';
+          if (fieldId === 'category') return '';
           return '';
         })
       },
@@ -78,8 +87,9 @@ describe('InventoryAddModalHandler', () => {
     );
   });
 
-  it('Given multiple valid lines When handle is called Then it creates inventories sequentially and updates message', async () => {
+  it('Given multiple valid lines with explicit category When handle is called Then it creates inventories sequentially with unified category and updates message', async () => {
     // Given
+    mockModalFields('洗剤,5\nパン,3', '日用品');
     const allItems = [
       {
         id: 'inventory-1',
@@ -91,7 +101,7 @@ describe('InventoryAddModalHandler', () => {
         id: 'inventory-2',
         name: 'パン',
         stock: 3,
-        category: '食料品'
+        category: '日用品'
       }
     ];
     repository.fetchAll.mockResolvedValue(allItems);
@@ -103,6 +113,7 @@ describe('InventoryAddModalHandler', () => {
     expect(handler.getCustomId()).toBe('inventory_add_modal');
     expect(interaction.deferReply).toHaveBeenCalledWith({ flags: ['Ephemeral'] });
     expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('items');
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('category');
     expect(metadataReader.getChannelMetadata).toHaveBeenCalledWith('channel-1');
     expect(inventoryService.create).toHaveBeenNthCalledWith(1, 'channel-1', {
       id: '00000000-0000-4000-8000-000000000029',
@@ -114,7 +125,7 @@ describe('InventoryAddModalHandler', () => {
       id: '00000000-0000-4000-8000-000000000029',
       name: 'パン',
       stock: 3,
-      category: '食料品'
+      category: '日用品'
     });
     expect(repository.fetchAll).toHaveBeenCalledWith('channel-1');
     expect(messageManager.createOrUpdateMessage).toHaveBeenCalledWith(
@@ -127,12 +138,9 @@ describe('InventoryAddModalHandler', () => {
     expect(interaction.deleteReply).toHaveBeenCalled();
   });
 
-  it('Given item without category When handle is called Then it uses metadata default category', async () => {
+  it('Given items without category and metadata default category When handle is called Then it uses metadata default category', async () => {
     // Given
-    interaction.fields.getTextInputValue = vi.fn((fieldId: string) => {
-      if (fieldId === 'items') return '歯磨き粉,2';
-      return '';
-    });
+    mockModalFields('歯磨き粉,2', '');
 
     // When
     await handler.handle(context);
@@ -144,16 +152,14 @@ describe('InventoryAddModalHandler', () => {
       stock: 2,
       category: '未分類'
     });
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('category');
     expect(messageManager.createOrUpdateMessage).toHaveBeenCalled();
   });
 
-  it('Given item without category and metadata default category When handle is called Then it uses empty category', async () => {
+  it('Given items without category and no metadata When handle is called Then it uses empty category', async () => {
     // Given
     metadataReader.getChannelMetadata.mockResolvedValue(null);
-    interaction.fields.getTextInputValue = vi.fn((fieldId: string) => {
-      if (fieldId === 'items') return '歯磨き粉,2';
-      return '';
-    });
+    mockModalFields('歯磨き粉,2', '');
 
     // When
     await handler.handle(context);
@@ -165,15 +171,13 @@ describe('InventoryAddModalHandler', () => {
       stock: 2,
       category: ''
     });
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('category');
     expect(messageManager.createOrUpdateMessage).toHaveBeenCalled();
   });
 
   it('Given invalid items format When handle is called Then it replies parse error', async () => {
     // Given
-    interaction.fields.getTextInputValue = vi.fn((fieldId: string) => {
-      if (fieldId === 'items') return '洗剤,abc,日用品';
-      return '';
-    });
+    mockModalFields('洗剤,abc', '');
 
     // When
     await handler.handle(context);
@@ -189,10 +193,7 @@ describe('InventoryAddModalHandler', () => {
 
   it('Given empty parsed items When handle is called Then it replies validation error', async () => {
     // Given
-    interaction.fields.getTextInputValue = vi.fn((fieldId: string) => {
-      if (fieldId === 'items') return '   \n';
-      return '';
-    });
+    mockModalFields('   \n', '');
 
     // When
     await handler.handle(context);
@@ -208,6 +209,7 @@ describe('InventoryAddModalHandler', () => {
 
   it('Given duplicated item When handle is called Then it skips item, logs warning and updates message', async () => {
     // Given
+    mockModalFields('洗剤,5\nパン,3', '日用品');
     inventoryService.create
       .mockResolvedValueOnce({ success: false, message: '同名のアイテムが既に存在します' })
       .mockResolvedValueOnce({ success: true });
@@ -217,6 +219,19 @@ describe('InventoryAddModalHandler', () => {
 
     // Then
     expect(inventoryService.create).toHaveBeenCalledTimes(2);
+    expect(inventoryService.create).toHaveBeenNthCalledWith(1, 'channel-1', {
+      id: '00000000-0000-4000-8000-000000000029',
+      name: '洗剤',
+      stock: 5,
+      category: '日用品'
+    });
+    expect(inventoryService.create).toHaveBeenNthCalledWith(2, 'channel-1', {
+      id: '00000000-0000-4000-8000-000000000029',
+      name: 'パン',
+      stock: 3,
+      category: '日用品'
+    });
+    expect(interaction.fields.getTextInputValue).toHaveBeenCalledWith('category');
     expect(logger.warn).toHaveBeenCalledWith('Skipped inventory item', {
       name: '洗剤',
       message: '同名のアイテムが既に存在します'

--- a/tests/utils/InventoryParser.test.ts
+++ b/tests/utils/InventoryParser.test.ts
@@ -1,4 +1,8 @@
-import { parseInventoryCsvText, formatInventoryCsvText } from '../../src/utils/InventoryParser';
+import {
+  parseInventoryCsvText,
+  parseInventoryAddCsvText,
+  formatInventoryCsvText,
+} from '../../src/utils/InventoryParser';
 
 describe('parseInventoryCsvText', () => {
   it('parses single line with category', () => {
@@ -42,6 +46,46 @@ describe('parseInventoryCsvText', () => {
   it('accepts decimal stock and rounds to 1 decimal', () => {
     expect(parseInventoryCsvText('洗剤,5.5,日用品')).toEqual([
       { name: '洗剤', stock: 5.5, category: '日用品' },
+    ]);
+  });
+});
+
+describe('parseInventoryAddCsvText', () => {
+  it('parses single line', () => {
+    expect(parseInventoryAddCsvText('洗剤,5')).toEqual([
+      { name: '洗剤', stock: 5 },
+    ]);
+  });
+
+  it('parses multiple lines', () => {
+    const text = '洗剤,5\nパン,3';
+    expect(parseInventoryAddCsvText(text)).toHaveLength(2);
+  });
+
+  it('skips empty lines', () => {
+    const text = '洗剤,5\n\n  \nパン,3';
+    expect(parseInventoryAddCsvText(text)).toHaveLength(2);
+  });
+
+  it('throws on too many tokens', () => {
+    expect(() => parseInventoryAddCsvText('a,1,b')).toThrow();
+  });
+
+  it('throws on empty name', () => {
+    expect(() => parseInventoryAddCsvText(',5')).toThrow();
+  });
+
+  it('throws on non-numeric stock', () => {
+    expect(() => parseInventoryAddCsvText('洗剤,abc')).toThrow();
+  });
+
+  it('throws on negative stock', () => {
+    expect(() => parseInventoryAddCsvText('洗剤,-1')).toThrow();
+  });
+
+  it('accepts decimal stock and rounds to 1 decimal', () => {
+    expect(parseInventoryAddCsvText('洗剤,5.5')).toEqual([
+      { name: '洗剤', stock: 5.5 },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- 在庫追加モーダルを `AddListModalHandler` と同様の2フィールド構成に変更（カテゴリフィールド独立、複数項目を1カテゴリに一括追加）
- items 入力を「名前,在庫数」の2列形式に簡素化し、行ごとのカテゴリ指定を廃止
- parser を分割: 2列専用 `parseInventoryAddCsvText` を新設し、既存の3列 `parseInventoryCsvText`（在庫更新モーダル用）と分離
- カテゴリ決定優先順位: モーダルの category 入力 > `metadata.defaultCategory` > 空文字

## 変更ファイル

- `src/buttons/InventoryAddButtonHandler.ts`: モーダルに category フィールドを追加、items を2列形式に
- `src/modals/InventoryAddModalHandler.ts`: 統一カテゴリ適用ロジック、`parseInventoryAddCsvText` への切替
- `src/utils/InventoryParser.ts`: `parseInventoryAddCsvText` 新設、共通バリデーションを内部ヘルパーへ抽出
- 上記3つに対応するテストファイル

## Test plan

- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm test` 全1018件パス
- [ ] Discord 上で `/init-inventory` 後、追加ボタン押下 → モーダルに category と items の2フィールドが表示されること
- [ ] category を入力＋複数行 items を入力 → 全アイテムが指定カテゴリで追加されること
- [ ] category 空＋items 入力 → metadata の `defaultCategory` が適用されること
- [ ] 在庫更新モーダル（`InventoryUpdateButtonHandler`）が従来通り3列形式で動作すること（リグレッション確認）